### PR TITLE
Fit a Beta distribution to the c parameter

### DIFF
--- a/convoys/__init__.py
+++ b/convoys/__init__.py
@@ -153,9 +153,9 @@ class Exponential(Model):
     def fit(self, C, N, B):
         def f(x):
             c, lambd = x
-            likelihood_observed = c * lambd * exp(-lambd*C)
-            likelihood_censored = (1 - c) + c * exp(-lambd*N)
-            neg_LL = -sum(log(B * likelihood_observed + (1 - B) * likelihood_censored + LOG_EPS))
+            log_likelihood_observed = log(c) + log(lambd) -lambd*C
+            log_likelihood_censored = log((1 - c) + c * exp(-lambd*N))
+            neg_LL = -sum(B * log_likelihood_observed + (1 - B) * log_likelihood_censored)
             return neg_LL
 
         c_initial = numpy.mean(B)

--- a/convoys/__init__.py
+++ b/convoys/__init__.py
@@ -228,10 +228,10 @@ class Weibull(Model):
         def f(x):
             c, lambd, k = x
             # PDF of Weibull: k * lambda * (x * lambda)^(k-1) * exp(-(t * lambda)^k)
-            likelihood_observed = c * k * lambd * (C * lambd)**(k-1) * exp(-(C*lambd)**k)
+            log_likelihood_observed = log(c) + log(k) + log(lambd) + (k-1)*(log(C) + log(lambd)) - (C*lambd)**k
             # CDF of Weibull: 1 - exp(-(t * lambda)^k)
             likelihood_censored = (1 - c) + c * exp(-(N*lambd)**k)
-            neg_LL = -sum(log(B * likelihood_observed + (1 - B) * likelihood_censored + LOG_EPS))
+            neg_LL = -sum(B * log_likelihood_observed + (1 - B) * log(likelihood_censored))
             return neg_LL
 
         c_initial = numpy.mean(B)

--- a/convoys/__init__.py
+++ b/convoys/__init__.py
@@ -149,7 +149,7 @@ class KaplanMeier(Model):
             return median(self.ps)
 
 
-class ExponentialBeta(Model):
+class Exponential(Model):
     # Compute the full posterior likelihood when assuming c ~ Beta(a, b)
     # If this model works, let's replace the bootstrapping
     def fit(self, C, N, B):
@@ -195,7 +195,7 @@ class ExponentialBeta(Model):
         return 1.0 / self.params['lambd']
 
 
-class WeibullBeta(Model):
+class Weibull(Model):
     def fit(self, C, N, B):
         def transform(x):
             p, q, r, s = x
@@ -239,7 +239,7 @@ class WeibullBeta(Model):
         return gamma(1 + 1./self.params['k']) / self.params['lambd']
 
 
-class GammaBeta(Model):
+class Gamma(Model):
     def fit(self, C, N, B):
         # TODO(erikbern): should compute Jacobian of this one
         def transform(x):
@@ -339,9 +339,9 @@ _models = {
     'basic': Basic,
     'kaplan-meier': KaplanMeier,
     'simple-binomial': SimpleBinomial,
-    'exponential': ExponentialBeta,
-    'weibull': WeibullBeta,
-    'gamma': GammaBeta,
+    'exponential': Exponential,
+    'weibull': Weibull,
+    'gamma': Gamma,
 }
 
 def plot_cohorts(data, t_max=None, title=None, group_min_size=0, max_groups=100, model='kaplan-meier', projection=None):

--- a/convoys/__init__.py
+++ b/convoys/__init__.py
@@ -149,164 +149,6 @@ class KaplanMeier(Model):
             return median(self.ps)
 
 
-class Exponential(Model):
-    def fit(self, C, N, B):
-        def f(x):
-            c, lambd = x
-            log_likelihood_observed = log(c) + log(lambd) -lambd*C
-            log_likelihood_censored = log((1 - c) + c * exp(-lambd*N))
-            neg_LL = -sum(B * log_likelihood_observed + (1 - B) * log_likelihood_censored)
-            return neg_LL
-
-        c_initial = numpy.mean(B)
-        lambd_initial = 1.0 / max(N)
-        lambd_max = 30.0 / max(N)
-        lambd = self.params.get('lambd')
-        res = scipy.optimize.minimize(
-            fun=f,
-            jac=grad(f),
-            x0=(c_initial, lambd_initial),
-            bounds=((1e-4, 1-1e-4),
-                    (lambd, lambd) if lambd else (1e-4, lambd_max)),
-            method='L-BFGS-B')
-        c, lambd = res.x
-        self.params = dict(c=c, lambd=lambd)
-
-    def predict(self, ts):
-        c, lambd = self.params['c'], self.params['lambd']
-        return ts, c * (1 - exp(-ts * lambd))
-
-    def predict_final(self):
-        return self.params['c']
-
-    def predict_time(self):
-        return 1.0 / self.params['lambd']
-
-
-class Gamma(Model):
-    def fit(self, C, N, B):
-        # TODO(erikbern): should compute Jacobian of this one
-        def f(x):
-            c, lambd, k = x
-            neg_LL = 0
-            # PDF of gamma: 1.0 / gamma(k) * lambda ^ k * t^(k-1) * exp(-t * lambda)
-            log_likelihood_observed = log(c) - gammaln(k) + k*log(lambd) + (k-1)*log(C + LOG_EPS) - lambd*C
-            # CDF of gamma: gammainc(k, lambda * t)
-            log_likelihood_censored = log((1 - c) + c * (1 - gammainc(k, lambd*N)) + LOG_EPS)
-            neg_LL = -sum(B * log_likelihood_observed + (1 - B) * log_likelihood_censored)
-            return neg_LL
-
-        c_initial = numpy.mean(B)
-        lambd_initial = 1.0 / max(C)
-        lambd_max = 100.0 / max(C)
-        k_initial = 10.0
-        lambd = self.params.get('lambd')
-        k = self.params.get('k')
-        res = scipy.optimize.minimize(
-            fun=f,
-            x0=(c_initial, lambd_initial, k_initial),
-            bounds=((1e-4, 1-1e-4),
-                    (lambd, lambd) if lambd else (1e-4, lambd_max),
-                    (k, k) if k else (1.0, 30.0)),
-            method='L-BFGS-B')
-        c, lambd, k = res.x
-        self.params = dict(c=c, lambd=lambd, k=k)
-
-    def predict(self, ts):
-        c, lambd, k = self.params['c'], self.params['lambd'], self.params['k']
-        return ts, c * gammainc(k, lambd*ts)
-
-    def predict_final(self):
-        return self.params['c']
-
-    def predict_time(self):
-        return self.params['k'] / self.params['lambd']
-
-
-class Weibull(Model):
-    def fit(self, C, N, B):
-        def f(x):
-            c, lambd, k = x
-            # PDF of Weibull: k * lambda * (x * lambda)^(k-1) * exp(-(t * lambda)^k)
-            log_likelihood_observed = log(c) + log(k) + log(lambd) + (k-1)*(log(C) + log(lambd)) - (C*lambd)**k
-            # CDF of Weibull: 1 - exp(-(t * lambda)^k)
-            likelihood_censored = (1 - c) + c * exp(-(N*lambd)**k)
-            neg_LL = -sum(B * log_likelihood_observed + (1 - B) * log(likelihood_censored))
-            return neg_LL
-
-        c_initial = numpy.mean(B)
-        lambd_initial = 1.0 / max(C)
-        lambd_max = 300.0 / max(C)
-        k_initial = 0.9
-        lambd = self.params.get('lambd')
-        k = self.params.get('k')
-        res = scipy.optimize.minimize(
-            fun=f,
-            jac=grad(f),
-            x0=(c_initial, lambd_initial, k_initial),
-            bounds=((1e-4, 1-1e-4),
-                    (lambd, lambd) if lambd else (1e-4, lambd_max),
-                    (k, k) if k else (0.1, 3.0)),
-            method='L-BFGS-B')
-        c, lambd, k = res.x
-        self.params = dict(c=c, lambd=lambd, k=k)
-
-    def predict(self, ts):
-        c, lambd, k = self.params['c'], self.params['lambd'], self.params['k']
-        return ts, c * (1 - exp(-(ts*lambd)**k))
-
-    def predict_final(self):
-        return self.params['c']
-
-    def predict_time(self):
-        return gamma(1 + 1./self.params['k']) / self.params['lambd']
-
-
-class Bootstrapper(Model):
-    def __init__(self, projection, params={}, n_bootstraps=100):
-        if projection == 'exponential':
-            base_fitter = lambda: Exponential(params=params)
-        elif projection == 'gamma':
-            base_fitter = lambda: Gamma(params=params)
-        elif projection == 'weibull':
-            base_fitter = lambda: Weibull(params=params)
-        else:
-            raise Exception('projection must be exponential/gamma/weibull (was: %s)' % projection)
-        self.models = [base_fitter() for i in range(n_bootstraps)]
-
-    def fit(self, C, N, B):
-        CNB = list(zip(C, N, B))
-        for i, model in enumerate(self.models):
-            CNB_bootstrapped = [random.choice(CNB) for _ in CNB]
-            C_bootstrapped = numpy.array([c for c, n, b in CNB_bootstrapped])
-            N_bootstrapped = numpy.array([n for c, n, b in CNB_bootstrapped])
-            B_bootstrapped = numpy.array([b for c, n, b in CNB_bootstrapped])
-            model.fit(C_bootstrapped, N_bootstrapped, B_bootstrapped)
-
-    def predict(self, ts, confidence_interval=False):
-        all_ts = numpy.array([model.predict(ts)[1] for model in self.models])
-        if confidence_interval:
-            return (ts, numpy.mean(all_ts, axis=0), numpy.percentile(all_ts, 5, axis=0), numpy.percentile(all_ts, 95, axis=0))
-        else:
-            return (ts, numpy.mean(all_ts, axis=0))
-
-    def predict_final(self, confidence_interval=False):
-        all_ps = numpy.array([model.predict_final() for model in self.models])
-        if confidence_interval:
-            return (numpy.mean(all_ps), numpy.percentile(all_ps, 5), numpy.percentile(all_ps, 95))
-        else:
-            return numpy.mean(all_ps)
-
-    def predict_time(self, confidence_interval=False):
-        # TODO(erikbern): not sure if it makes sense to use median here,
-        # but the mean is problematic because the distribution is so skewed.
-        all_ps = numpy.array([model.predict_time() for model in self.models])
-        if confidence_interval:
-            return (numpy.median(all_ps), numpy.percentile(all_ps, 5), numpy.percentile(all_ps, 95))
-        else:
-            return numpy.median(all_ps)
-
-
 class ExponentialBeta(Model):
     # Compute the full posterior likelihood when assuming c ~ Beta(a, b)
     # If this model works, let's replace the bootstrapping
@@ -493,29 +335,6 @@ def split_by_group(data, group_min_size, max_groups):
     return groups, js
 
 
-def get_params(js, projection, share_params, t_factor):
-    if share_params:
-        if projection == 'exponential':
-            m = Exponential()
-        elif projection == 'gamma':
-            m = Gamma()
-        elif projection == 'weibull':
-            m = Weibull()
-        else:
-            raise Exception('sharing params only works if projection is exponential/gamma/weibull (was: %s)' % projection)
-        pooled_data = []
-        for v in js.values():
-            pooled_data += v
-        C, N, B = get_arrays(pooled_data, t_factor)
-        m.fit(C, N, B)
-        if share_params is True:
-            return {k: m.params[k] for k in ['k', 'lambd'] if k in m.params}
-        else:
-            return {k: m.params[k] for k in share_params if k in m.params}
-    else:
-        return {}
-
-
 _models = {
     'basic': Basic,
     'kaplan-meier': KaplanMeier,
@@ -525,7 +344,7 @@ _models = {
     'gamma': GammaBeta,
 }
 
-def plot_cohorts(data, t_max=None, title=None, group_min_size=0, max_groups=100, model='kaplan-meier', projection=None, share_params=False):
+def plot_cohorts(data, t_max=None, title=None, group_min_size=0, max_groups=100, model='kaplan-meier', projection=None):
     # Set x scale
     if t_max is None:
         t_max = max(now - created_at for group, created_at, converted_at, now in data)
@@ -570,7 +389,7 @@ def plot_cohorts(data, t_max=None, title=None, group_min_size=0, max_groups=100,
     pyplot.gca().grid(True)
 
 
-def plot_timeseries(data, window, model='kaplan-meier', group_min_size=0, max_groups=100, window_min_size=1, stride=None, share_params=False, title=None, time=False):
+def plot_timeseries(data, window, model='kaplan-meier', group_min_size=0, max_groups=100, window_min_size=1, stride=None, title=None, time=False):
     if stride is None:
         stride = window
 

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -7,7 +7,7 @@ matplotlib.use('Agg')  # Needed for matplotlib to run in Travis
 import convoys
 
 
-def test_exponential_model(c=0.05, lambd=0.1, n=100000, cls=convoys.Exponential):
+def test_exponential_model(c=0.3, lambd=0.1, n=100000, cls=convoys.Exponential):
     # With a really long observation window, the rate should converge to the measured
     C = numpy.array([random.random() < c and scipy.stats.expon.rvs(scale=1.0/lambd) or 0.0 for x in range(n)])
     N = numpy.array([100 for converted_at in C])
@@ -23,7 +23,7 @@ def test_exponential_beta_model():
     return test_exponential_model(cls=convoys.ExponentialBeta)
 
 
-def test_gamma_model(c=0.05, lambd=0.1, k=10.0, n=100000, cls=convoys.Gamma):
+def test_gamma_model(c=0.3, lambd=0.1, k=3.0, n=100000, cls=convoys.Gamma):
     C = numpy.array([random.random() < c and scipy.stats.gamma.rvs(a=k, scale=1.0/lambd) or 0.0 for x in range(n)])
     N = numpy.array([1000 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])
@@ -39,7 +39,7 @@ def test_gamma_beta_model():
     return test_gamma_model(cls=convoys.GammaBeta)
 
 
-def test_weibull_model(c=0.05, lambd=0.1, k=0.5, n=100000, cls=convoys.Weibull):
+def test_weibull_model(c=0.3, lambd=0.1, k=0.5, n=100000, cls=convoys.Weibull):
     # TODO: remove this one, only run the WeibullBeta
     def sample_weibull():
         # scipy.stats is garbage for this
@@ -60,7 +60,7 @@ def test_weibull_beta_model():
     return test_weibull_model(cls=convoys.WeibullBeta)
 
 
-def test_bootstrapped_exponential_model(c=0.05, lambd=0.1, n=10000):
+def test_bootstrapped_exponential_model(c=0.3, lambd=0.1, n=10000):
     C = numpy.array([random.random() < c and scipy.stats.expon.rvs(scale=1.0/lambd) or 0.0 for x in range(n)])
     N = numpy.array([100 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])
@@ -75,7 +75,7 @@ def test_bootstrapped_exponential_model(c=0.05, lambd=0.1, n=10000):
     assert 0.95*c_hi < y_hi < 1.05 * c_hi
 
 
-def test_exponential_beta_model_2(c=0.05, lambd=0.1, n=10000):
+def test_exponential_beta_model_2(c=0.3, lambd=0.1, n=10000):
     C = numpy.array([random.random() < c and scipy.stats.expon.rvs(scale=1.0/lambd) or 0.0 for x in range(n)])
     N = numpy.array([100 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])
@@ -92,7 +92,7 @@ def test_exponential_beta_model_2(c=0.05, lambd=0.1, n=10000):
     assert 0.95*c_hi < y_hi < 1.05 * c_hi
 
 
-def _get_data(c=0.05, k=10, lambd=0.1, n=1000):
+def _get_data(c=0.3, k=10, lambd=0.1, n=1000):
     data = []
     now = datetime.datetime(2000, 7, 1)
     for x in range(n):

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -7,40 +7,39 @@ matplotlib.use('Agg')  # Needed for matplotlib to run in Travis
 import convoys
 
 
-def test_exponential_model(c=0.3, lambd=0.1, n=100000, cls=convoys.Exponential):
+def test_exponential_model(c=0.3, lambd=0.1, n=100000):
     # With a really long observation window, the rate should converge to the measured
     C = numpy.array([random.random() < c and scipy.stats.expon.rvs(scale=1.0/lambd) or 0.0 for x in range(n)])
     N = numpy.array([100 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])
     c = numpy.mean(B)
-    model = cls()
+    model = convoys.ExponentialBeta()
     model.fit(C, N, B)
     assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd
 
+    # Check the confidence intervals
+    y, y_lo, y_hi = model.predict_final(confidence_interval=True)
+    c_lo = scipy.stats.beta.ppf(0.05, n*c, n*(1-c))
+    c_hi = scipy.stats.beta.ppf(0.95, n*c, n*(1-c))
+    assert 0.95*c < y < 1.05 * c
+    assert 0.95*c_lo < y_lo < 1.05 * c_lo
+    assert 0.95*c_hi < y_hi < 1.05 * c_hi
 
-def test_exponential_beta_model():
-    return test_exponential_model(cls=convoys.ExponentialBeta)
 
-
-def test_gamma_model(c=0.3, lambd=0.1, k=3.0, n=100000, cls=convoys.Gamma):
+def test_gamma_model(c=0.3, lambd=0.1, k=3.0, n=100000):
     C = numpy.array([random.random() < c and scipy.stats.gamma.rvs(a=k, scale=1.0/lambd) or 0.0 for x in range(n)])
     N = numpy.array([1000 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])
     c = numpy.mean(B)
-    model = cls()
+    model = convoys.GammaBeta()
     model.fit(C, N, B)
     assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd
     assert 0.95*k < model.params['k'] < 1.05*k
 
 
-def test_gamma_beta_model():
-    return test_gamma_model(cls=convoys.GammaBeta)
-
-
-def test_weibull_model(c=0.3, lambd=0.1, k=0.5, n=100000, cls=convoys.Weibull):
-    # TODO: remove this one, only run the WeibullBeta
+def test_weibull_model(c=0.3, lambd=0.1, k=0.5, n=100000):
     def sample_weibull():
         # scipy.stats is garbage for this
         # exp(-(x * lambda)^k) = y
@@ -49,47 +48,11 @@ def test_weibull_model(c=0.3, lambd=0.1, k=0.5, n=100000, cls=convoys.Weibull):
     C = numpy.array([b and sample_weibull() or 1.0 for b in B])
     N = numpy.array([1000 for b in B])
     c = numpy.mean(B)
-    model = cls()
+    model = convoys.WeibullBeta()
     model.fit(C, N, B)
     assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd
     assert 0.95*k < model.params['k'] < 1.05*k
-
-
-def test_weibull_beta_model():
-    return test_weibull_model(cls=convoys.WeibullBeta)
-
-
-def test_bootstrapped_exponential_model(c=0.3, lambd=0.1, n=10000):
-    C = numpy.array([random.random() < c and scipy.stats.expon.rvs(scale=1.0/lambd) or 0.0 for x in range(n)])
-    N = numpy.array([100 for converted_at in C])
-    B = numpy.array([bool(converted_at > 0) for converted_at in C])
-    c = numpy.mean(B)
-    model = convoys.Bootstrapper('exponential')
-    model.fit(C, N, B)
-    y, y_lo, y_hi = model.predict_final(confidence_interval=True)
-    c_lo = scipy.stats.beta.ppf(0.05, n*c, n*(1-c))
-    c_hi = scipy.stats.beta.ppf(0.95, n*c, n*(1-c))
-    assert 0.95*c < y < 1.05 * c
-    assert 0.95*c_lo < y_lo < 1.05 * c_lo
-    assert 0.95*c_hi < y_hi < 1.05 * c_hi
-
-
-def test_exponential_beta_model_2(c=0.3, lambd=0.1, n=10000):
-    C = numpy.array([random.random() < c and scipy.stats.expon.rvs(scale=1.0/lambd) or 0.0 for x in range(n)])
-    N = numpy.array([100 for converted_at in C])
-    B = numpy.array([bool(converted_at > 0) for converted_at in C])
-    c = numpy.mean(B)
-    model = convoys.ExponentialBeta()
-    model.fit(C, N, B)
-    y = model.predict_final()
-    assert 0.95*c < y < 1.05 * c
-    y, y_lo, y_hi = model.predict_final(confidence_interval=True)
-    c_lo = scipy.stats.beta.ppf(0.05, n*c, n*(1-c))
-    c_hi = scipy.stats.beta.ppf(0.95, n*c, n*(1-c))
-    assert 0.95*c < y < 1.05 * c
-    assert 0.95*c_lo < y_lo < 1.05 * c_lo
-    assert 0.95*c_hi < y_hi < 1.05 * c_hi
 
 
 def _get_data(c=0.3, k=10, lambd=0.1, n=1000):
@@ -115,7 +78,3 @@ def test_plot_cohorts():
 
 def test_plot_conversion():
     convoys.plot_timeseries(_get_data(), window=datetime.timedelta(days=7), model='gamma')
-
-
-def test_plot_cohorts_share_params():
-    convoys.plot_cohorts(_get_data(), projection='gamma', share_params=['k'])

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -31,7 +31,8 @@ def test_gamma_model(c=0.05, lambd=0.1, k=10.0, n=100000):
     assert 0.95*k < model.params['k'] < 1.05*k
 
 
-def test_weibull_model(c=0.05, lambd=0.1, k=0.5, n=100000):
+def test_weibull_model(c=0.05, lambd=0.1, k=0.5, n=100000, cls=convoys.Weibull):
+    # TODO: remove this one, only run the WeibullBeta
     def sample_weibull():
         # scipy.stats is garbage for this
         # exp(-(x * lambda)^k) = y
@@ -40,11 +41,15 @@ def test_weibull_model(c=0.05, lambd=0.1, k=0.5, n=100000):
     C = numpy.array([b and sample_weibull() or 1.0 for b in B])
     N = numpy.array([1000 for b in B])
     c = numpy.mean(B)
-    model = convoys.Weibull()
+    model = cls()
     model.fit(C, N, B)
-    assert 0.95*c < model.params['c'] < 1.05*c
+    assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd
     assert 0.95*k < model.params['k'] < 1.05*k
+
+
+def test_weibull_beta_model():
+    return test_weibull_model(cls=convoys.WeibullBeta)
 
 
 def test_bootstrapped_exponential_model(c=0.05, lambd=0.1, n=10000):

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -62,6 +62,23 @@ def test_bootstrapped_exponential_model(c=0.05, lambd=0.1, n=10000):
     assert 0.95*c_hi < y_hi < 1.05 * c_hi
 
 
+def test_exponential_beta_model(c=0.05, lambd=0.1, n=10000):
+    C = numpy.array([random.random() < c and scipy.stats.expon.rvs(scale=1.0/lambd) or 0.0 for x in range(n)])
+    N = numpy.array([100 for converted_at in C])
+    B = numpy.array([bool(converted_at > 0) for converted_at in C])
+    c = numpy.mean(B)
+    model = convoys.ExponentialBeta()
+    model.fit(C, N, B)
+    y = model.predict_final()
+    assert 0.95*c < y < 1.05 * c
+    y, y_lo, y_hi = model.predict_final(confidence_interval=True)
+    c_lo = scipy.stats.beta.ppf(0.05, n*c, n*(1-c))
+    c_hi = scipy.stats.beta.ppf(0.95, n*c, n*(1-c))
+    assert 0.95*c < y < 1.05 * c
+    assert 0.95*c_lo < y_lo < 1.05 * c_lo
+    assert 0.95*c_hi < y_hi < 1.05 * c_hi
+
+
 def _get_data(c=0.05, k=10, lambd=0.1, n=1000):
     data = []
     now = datetime.datetime(2000, 7, 1)

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -13,7 +13,7 @@ def test_exponential_model(c=0.3, lambd=0.1, n=100000):
     N = numpy.array([100 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])
     c = numpy.mean(B)
-    model = convoys.ExponentialBeta()
+    model = convoys.Exponential()
     model.fit(C, N, B)
     assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd
@@ -32,7 +32,7 @@ def test_gamma_model(c=0.3, lambd=0.1, k=3.0, n=100000):
     N = numpy.array([1000 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])
     c = numpy.mean(B)
-    model = convoys.GammaBeta()
+    model = convoys.Gamma()
     model.fit(C, N, B)
     assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd
@@ -48,7 +48,7 @@ def test_weibull_model(c=0.3, lambd=0.1, k=0.5, n=100000):
     C = numpy.array([b and sample_weibull() or 1.0 for b in B])
     N = numpy.array([1000 for b in B])
     c = numpy.mean(B)
-    model = convoys.WeibullBeta()
+    model = convoys.Weibull()
     model.fit(C, N, B)
     assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -7,28 +7,36 @@ matplotlib.use('Agg')  # Needed for matplotlib to run in Travis
 import convoys
 
 
-def test_exponential_model(c=0.05, lambd=0.1, n=100000):
+def test_exponential_model(c=0.05, lambd=0.1, n=100000, cls=convoys.Exponential):
     # With a really long observation window, the rate should converge to the measured
     C = numpy.array([random.random() < c and scipy.stats.expon.rvs(scale=1.0/lambd) or 0.0 for x in range(n)])
     N = numpy.array([100 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])
     c = numpy.mean(B)
-    model = convoys.Exponential()
+    model = cls()
     model.fit(C, N, B)
-    assert 0.95*c < model.params['c'] < 1.05*c
+    assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd
 
 
-def test_gamma_model(c=0.05, lambd=0.1, k=10.0, n=100000):
+def test_exponential_beta_model():
+    return test_exponential_model(cls=convoys.ExponentialBeta)
+
+
+def test_gamma_model(c=0.05, lambd=0.1, k=10.0, n=100000, cls=convoys.Gamma):
     C = numpy.array([random.random() < c and scipy.stats.gamma.rvs(a=k, scale=1.0/lambd) or 0.0 for x in range(n)])
     N = numpy.array([1000 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])
     c = numpy.mean(B)
-    model = convoys.Gamma()
+    model = cls()
     model.fit(C, N, B)
-    assert 0.95*c < model.params['c'] < 1.05*c
+    assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd
     assert 0.95*k < model.params['k'] < 1.05*k
+
+
+def test_gamma_beta_model():
+    return test_gamma_model(cls=convoys.GammaBeta)
 
 
 def test_weibull_model(c=0.05, lambd=0.1, k=0.5, n=100000, cls=convoys.Weibull):
@@ -67,7 +75,7 @@ def test_bootstrapped_exponential_model(c=0.05, lambd=0.1, n=10000):
     assert 0.95*c_hi < y_hi < 1.05 * c_hi
 
 
-def test_exponential_beta_model(c=0.05, lambd=0.1, n=10000):
+def test_exponential_beta_model_2(c=0.05, lambd=0.1, n=10000):
     C = numpy.array([random.random() < c and scipy.stats.expon.rvs(scale=1.0/lambd) or 0.0 for x in range(n)])
     N = numpy.array([100 for converted_at in C])
     B = numpy.array([bool(converted_at > 0) for converted_at in C])


### PR DESCRIPTION
Instead of using bootstrapping to estimate uncertainty of c, just fit a Beta distribution directly

This is probably 10-100x faster although a few more lines of math (lots of `gammaln`)

Will do the same thing for Weibull and Gamma and then remove the bootstrapping (and the old non-beta models). Will also remove a few other things like sharing parameters etc.