### PR TITLE
weibull regression (MAP and bayesian version)

### DIFF
--- a/convoys/bayesian.py
+++ b/convoys/bayesian.py
@@ -1,0 +1,40 @@
+import numpy
+import pymc3
+import random
+from scipy.special import expit
+from pymc3.math import dot, sigmoid, log, exp
+
+from convoys import Model
+
+class WeibullRegression(Model):
+    def fit(self, X, B, T):
+        n, k = X.shape
+        with pymc3.Model() as m:
+            beta_sd = pymc3.Exponential('beta_sd', 1.0)  # Weak prior for the regression coefficients
+            beta = pymc3.Normal('beta', mu=0, sd=beta_sd, shape=(k,))  # Regression coefficients
+            c = sigmoid(dot(X, beta))  # Conversion rates for each example
+            k = pymc3.Lognormal('k', mu=0, sd=1.0)  # Weak prior around k=1
+            lambd = pymc3.Exponential('lambd', 0.1)  # Weak prior
+
+            # PDF of Weibull: k * lambda * (x * lambda)^(k-1) * exp(-(t * lambda)^k)
+            LL_observed = log(c) + log(k) + log(lambd) + (k-1)*(log(T) + log(lambd)) - (T*lambd)**k
+            # CDF of Weibull: 1 - exp(-(t * lambda)^k)
+            LL_censored = log((1-c) + c * exp(-(T*lambd)**k))
+
+            # We need to implement the likelihood using pymc3.Potential (custom likelihood)
+            # https://github.com/pymc-devs/pymc3/issues/826
+            logp = B * LL_observed + (1 - B) * LL_censored
+            logpvar = pymc3.Potential('logpvar', logp.sum())
+
+            self.trace = pymc3.sample(n_simulations=500, tune=500, discard_tuned_samples=True, njobs=1)
+            print('done')
+        print('done 2')
+
+    def predict(self):
+        pass  # TODO: implement
+
+    def predict_final(self, x):
+        return numpy.mean(expit(numpy.dot(self.trace['beta'], x)))
+
+    def predict_time(self):
+        pass  # TODO: implement

--- a/convoys/bayesian.py
+++ b/convoys/bayesian.py
@@ -7,6 +7,9 @@ from pymc3.math import dot, sigmoid, log, exp
 from convoys import Model
 
 class WeibullRegression(Model):
+    # This is a super-experimental model that uses pymc3 to sample from the posterior
+    # Unfortunately, it's way too slow to use for any datasets larger than n=1000
+    # I'm keeping it here as a way to double check the results of models
     def fit(self, X, B, T):
         n, k = X.shape
         with pymc3.Model() as m:

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -1,0 +1,40 @@
+import numpy
+import pymc3
+import random
+from scipy.special import expit
+from pymc3.math import dot, sigmoid, log, exp
+
+from convoys import Model
+
+class WeibullRegression(Model):
+    def fit(self, X, B, T):
+        n, k = X.shape
+        with pymc3.Model() as m:
+            beta_sd = pymc3.Exponential('beta_sd', 1.0)  # Weak prior for the regression coefficients
+            beta = pymc3.Normal('beta', mu=0, sd=beta_sd, shape=(k,))  # Regression coefficients
+            c = sigmoid(dot(X, beta))  # Conversion rates for each example
+            k = pymc3.Lognormal('k', mu=0, sd=1.0)  # Weak prior around k=1
+            lambd = pymc3.Exponential('lambd', 0.1)  # Weak prior
+
+            # PDF of Weibull: k * lambda * (x * lambda)^(k-1) * exp(-(t * lambda)^k)
+            LL_observed = log(c) + log(k) + log(lambd) + (k-1)*(log(T) + log(lambd)) - (T*lambd)**k
+            # CDF of Weibull: 1 - exp(-(t * lambda)^k)
+            LL_censored = log((1-c) + c * exp(-(T*lambd)**k))
+
+            # We need to implement the likelihood using pymc3.Potential (custom likelihood)
+            # https://github.com/pymc-devs/pymc3/issues/826
+            logp = B * LL_observed + (1 - B) * LL_censored
+            logpvar = pymc3.Potential('logpvar', logp.sum())
+
+            self.trace = pymc3.sample(n_simulations=500, tune=500, discard_tuned_samples=True, njobs=1)
+            print('done')
+        print('done 2')
+
+    def predict(self):
+        pass  # TODO: implement
+
+    def predict_final(self, x):
+        return numpy.mean(expit(numpy.dot(self.trace['beta'], x)))
+
+    def predict_time(self):
+        pass  # TODO: implement

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -30,7 +30,8 @@ class WeibullRegression(Model):
             hess=hessian(f),
             x0=numpy.zeros(k+2),
             method='trust-ncg')
-        log_lambd, log_k, *beta = res.x
+        log_lambd, log_k = res.x[0], res.x[1]
+        beta = res.x[2:]
         # Compute hessian of betas
         beta_hessian = hessian(f)(res.x)[2:,2:]
         self.params = dict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ autograd==1.2
 lifelines==0.11.2
 matplotlib>=2.0.0
 numpy
+pymc3==3.3
 scipy
 seaborn==0.8.1
 six==1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ autograd==1.2
 lifelines==0.11.2
 matplotlib>=2.0.0
 numpy
-pymc3==3.3
 scipy
 seaborn==0.8.1
 six==1.11.0

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -57,7 +57,6 @@ def test_weibull_model(c=0.3, lambd=0.1, k=0.5, n=100000):
     assert 0.95*k < model.params['k'] < 1.05*k
 
 
-@pytest.mark.skip
 def test_weibull_regression_model(cs=[0.3, 0.5, 0.7], lambd=0.1, k=0.5, n=10000):
     def sample_weibull():
         return (-numpy.log(random.random())) ** (1.0/k) / lambd

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -1,10 +1,12 @@
 import datetime
 import matplotlib
 import numpy
+import pytest
 import random
 import scipy.stats
 matplotlib.use('Agg')  # Needed for matplotlib to run in Travis
 import convoys
+import convoys.regression
 
 
 def test_exponential_model(c=0.3, lambd=0.1, n=100000):
@@ -53,6 +55,20 @@ def test_weibull_model(c=0.3, lambd=0.1, k=0.5, n=100000):
     assert 0.95*c < model.predict_final() < 1.05*c
     assert 0.95*lambd < model.params['lambd'] < 1.05*lambd
     assert 0.95*k < model.params['k'] < 1.05*k
+
+
+@pytest.mark.skip
+def test_weibull_regression_model(cs=[0.3, 0.5, 0.7], lambd=0.1, k=0.5, n=10000):
+    def sample_weibull():
+        return (-numpy.log(random.random())) ** (1.0/k) / lambd
+    X = numpy.array([[1] + [r % len(cs) == j for j in range(len(cs))] for r in range(n)])
+    B = numpy.array([bool(random.random() < cs[r % len(cs)]) for r in range(n)])
+    T = numpy.array([b and sample_weibull() or 1000 for b in B])
+    model = convoys.regression.WeibullRegression()
+    model.fit(X, B, T)
+    for r, c in enumerate(cs):
+        x = [1] + [int(r == j) for j in range(len(cs))]
+        assert 0.95 * c < model.predict_final(x) < 1.05 * c
 
 
 def _get_data(c=0.3, k=10, lambd=0.1, n=1000):


### PR DESCRIPTION
Implemented a regression model using pymc3, so fully Bayesian.

The good news is that it was very easy to implement (once I discovered the pymc3.Potential class). The bad news is this is slow as hell. It barely works for more than a few thousand datapoints – whereas the current models happily fit 100k datapoints in a few seconds.

I'm tempted to revert to my original idea of just fitting this using MAP and then computing the Hessian of the MAP to get a normal approximation of the posterior distribution. Seems a bit janky but I think it will be a pretty good approximation in practice, and probably ~100x faster.