### PR TITLE
fix numerical issues with the nonparametric model

### DIFF
--- a/convoys/single.py
+++ b/convoys/single.py
@@ -47,7 +47,7 @@ class KaplanMeier(SingleModel):
 
 
 class Nonparametric(SingleModel):
-    def fit(self, B, T, n=1000):
+    def fit(self, B, T, n=100):
         # We're going to fit c and p_0, p_1, ...
         # so that the probability of conversion at time i is c * (1 - p_0) * ... p_i
         # What's the total likelihood
@@ -88,20 +88,22 @@ class Nonparametric(SingleModel):
 
         with tf.Session() as sess:
             tf_utils.optimize(sess, LL, (z, beta))
+            # Note: we only store the diagonal of the Hessian, since empirically, off-diagonal
+            # elements are almost zero, and working with the full covariance matrix causes
+            # numpy.random.multivariate_normal to break.
             self.params = {
                 'beta': sess.run(beta),
                 'z': sess.run(z),
                 'beta_std': tf_utils.get_hessian(sess, LL, beta) ** -0.5,
-                'z_cov': numpy.linalg.inv(tf_utils.get_hessian(sess, LL, z)),
+                'z_std': numpy.diag(tf_utils.get_hessian(sess, LL, z)) ** -0.5,  # TODO: seems inefficient
             }
-            # TODO: on synthetic data, z_cov is extremely close to diagonal
-            # Would be much faster/easier to just compute & store a diagonal matrix
 
     def predict(self, t, ci=None, n=1000):
         t = numpy.array(t)
         if ci:
             betas = numpy.random.normal(self.params['beta'], self.params['beta_std'], n)
-            zs = numpy.random.multivariate_normal(self.params['z'], self.params['z_cov'], n).T
+            zs = numpy.random.normal(self.params['z'], self.params['z_std'], size=(n,) + self.params['z'].shape).T
+            zs = numpy.clip(zs, -10, 10)  # Fix crazy outliers
         else:
             betas = self.params['beta']
             zs = self.params['z']

--- a/convoys/single.py
+++ b/convoys/single.py
@@ -95,7 +95,7 @@ class Nonparametric(SingleModel):
                 'beta': sess.run(beta),
                 'z': sess.run(z),
                 'beta_std': tf_utils.get_hessian(sess, LL, beta) ** -0.5,
-                'z_std': numpy.diag(tf_utils.get_hessian(sess, LL, z)) ** -0.5,  # TODO: seems inefficient
+                'z_std': numpy.maximum(numpy.diag(tf_utils.get_hessian(sess, LL, z)), 0) ** -0.5,  # TODO: seems inefficient
             }
 
     def predict(self, t, ci=None, n=1000):


### PR DESCRIPTION
Found a few issues

* Something with the covariance matrix not being positive semidefinite, causing `numpy.random.normal_multivariate` to complain and generate bogus values. This is despite eigenvalues being all positive
* A few of the variances were super large, causing enormous values of `z` that `expit` can't handle. Clipping fixes that problem
* It seems like a bias is introduced due to maybe floating point rounding. Not sure what's up, but with `n=1000` its end up having a fairly substantial upwards bias early in the distribution, whereas this disappears for `n=100`. Not quite sure what's up.

After these changes, Weibull estimation of synthetic Weibull data lines up fairly well with the nonparametric estimation

![image](https://user-images.githubusercontent.com/1027979/37688983-1083d37c-2c79-11e8-9f7b-09984d59de70.png)

![image](https://user-images.githubusercontent.com/1027979/37688984-127dc372-2c79-11e8-8c4e-4d5d50727e4b.png)
