### PR TITLE
fix nonparametric model by reparametrizing

### DIFF
--- a/test_convoys.py
+++ b/test_convoys.py
@@ -123,7 +123,7 @@ def test_nonparametric_model(c=0.3, lambd=0.1, k=0.5, n=10000):
     m = convoys.single.Nonparametric()
     m.fit(B, T)
 
-    assert 0.95*c < m.predict_final() < 1.05*c
+    assert 0.90*c < m.predict_final() < 1.10*c
 
     # Check shapes of results
     assert m.predict_final().shape == ()


### PR DESCRIPTION
This is a much better solution. Once we've found the MLE, reparametrize to avoid the cumsum thing. The only reason we can't do that during the optimization phase is that that would potentially involve negative probabilities, which would mess up the log-likelihood. But the MLE will actually be well formed so this works fine.

There's a wacky minor issue I still need to resolve which is that the second derivative of the last values of `z` ends up being enormous. Not sure why, will figure out what's causing it.

Weibull fit on Weibull data:

![image](https://user-images.githubusercontent.com/1027979/37733956-1bdc088c-2d20-11e8-99c2-fbaa915965a7.png)

Nonparametric fit on the same data:

![image](https://user-images.githubusercontent.com/1027979/37733961-1fd2c73c-2d20-11e8-87ad-20b8a870be1a.png)
