### PR TITLE
Minibatches, dropout, fix Gamma, easier learning algorithm

### DIFF
--- a/convoys/multi.py
+++ b/convoys/multi.py
@@ -13,16 +13,14 @@ class RegressionToMulti(MultiModel):
 
     def fit(self, G, B, T):
         self._n_groups = max(G) + 1
-        X = numpy.zeros((len(G), self._n_groups+1))
-        X[:,0] = 1.0
+        X = numpy.zeros((len(G), self._n_groups))
         for i, group in enumerate(G):
-            X[i,group+1] = 1
+            X[i,group] = 1
         self._base_model.fit(X, B, T)
 
     def _get_x(self, group):
-        x = numpy.zeros(self._n_groups+1)
-        x[0] = 1
-        x[group+1] = 1
+        x = numpy.zeros(self._n_groups)
+        x[group] = 1
         return x
 
     def predict(self, group, t, *args, **kwargs):

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -150,7 +150,7 @@ class Gamma(RegressionModel):
             # So let's just try small perturbations
             k_value = sess.run(k)
             res = {}
-            for k_mult in [0.99, 1.0, 1.01]:
+            for k_mult in [0.97, 1.0, 1.03]:
                 sess.run(assign_k, feed_dict={new_k: k_value * k_mult})
                 res[k_value * k_mult] = sess.run(LL, feed_dict=feed_dict)
             sess.run(assign_k, feed_dict={new_k: max(res.keys(), key=res.get)})

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -13,15 +13,13 @@ class Exponential(RegressionModel):
         n, k = X.shape
         X_batch, B_batch, T_batch = tf_utils.get_batch_placeholders((X, B, T))
 
-        alpha = tf.Variable(tf.zeros([k]), 'alpha')
-        beta = tf.Variable(tf.zeros([k]), 'beta')
-        a = tf.Variable(tf.zeros([]), 'a')
-        b = tf.Variable(tf.zeros([]), 'b')
+        alpha = tf.Variable(tf.zeros([k]), name='alpha')
+        beta = tf.Variable(tf.zeros([k]), name='beta')
+        a = tf.Variable(tf.zeros([]), name='a')
+        b = tf.Variable(tf.zeros([]), name='b')
         X_batch = tf.nn.dropout(X_batch, keep_prob=0.5)
         X_prod_alpha = tf.squeeze(tf.matmul(X_batch, tf.expand_dims(alpha, -1)), 1) + a
         X_prod_beta = tf.squeeze(tf.matmul(X_batch, tf.expand_dims(beta, -1)), 1) + b
-        X_prod_alpha = tf.squeeze(tf.matmul(X, tf.expand_dims(alpha, -1)), 1) + a
-        X_prod_beta = tf.squeeze(tf.matmul(X, tf.expand_dims(beta, -1)), 1) + b
         lambd = tf.exp(X_prod_alpha)
         c = tf.sigmoid(X_prod_beta)
 
@@ -35,7 +33,7 @@ class Exponential(RegressionModel):
 
         with tf.Session() as sess:
             feed_dict = {X_batch: X, B_batch: B, T_batch: T}
-            tf_utils.optimize(sess, LL, (alpha, beta), feed_dict)
+            tf_utils.optimize(sess, LL, feed_dict)
             self.params = {
                 'alpha': sess.run(alpha),
                 'beta': sess.run(beta),
@@ -65,11 +63,11 @@ class Weibull(RegressionModel):
         n, k = X.shape
         X_batch, B_batch, T_batch = tf_utils.get_batch_placeholders((X, B, T))
 
-        alpha = tf.Variable(tf.zeros([k]), 'alpha')
-        beta = tf.Variable(tf.zeros([k]), 'beta')
-        a = tf.Variable(tf.zeros([]), 'a')
-        b = tf.Variable(tf.zeros([]), 'b')
-        log_k_var = tf.Variable(tf.zeros([]), 'log_k')
+        alpha = tf.Variable(tf.zeros([k]), name='alpha')
+        beta = tf.Variable(tf.zeros([k]), name='beta')
+        a = tf.Variable(tf.zeros([]), name='a')
+        b = tf.Variable(tf.zeros([]), name='b')
+        log_k_var = tf.Variable(tf.zeros([]), name='log_k')
         X_batch = tf.nn.dropout(X_batch, keep_prob=0.5)
         X_prod_alpha = tf.squeeze(tf.matmul(X_batch, tf.expand_dims(alpha, -1)), 1) + a
         X_prod_beta = tf.squeeze(tf.matmul(X_batch, tf.expand_dims(beta, -1)), 1) + b
@@ -89,15 +87,15 @@ class Weibull(RegressionModel):
 
         with tf.Session() as sess:
             feed_dict = {X_batch: X, B_batch: B, T_batch: T}
-            tf_utils.optimize(sess, LL_penalized, (alpha, beta, log_k_var), feed_dict)
+            tf_utils.optimize(sess, LL, feed_dict)
             self.params = {
                 'alpha': sess.run(alpha),
                 'beta': sess.run(beta),
                 'a': sess.run(a),  # TODO: store hessian
                 'b': sess.run(b),  # TODO: store hessian
                 'k': sess.run(k),
-                'alpha_hessian': tf_utils.get_hessian(sess, LL_penalized, feed_dict, alpha),
-                'beta_hessian': tf_utils.get_hessian(sess, LL_penalized, feed_dict, beta),
+                'alpha_hessian': tf_utils.get_hessian(sess, LL, feed_dict, alpha),
+                'beta_hessian': tf_utils.get_hessian(sess, LL, feed_dict, beta),
             }
 
     def predict(self, x, t, ci=None, n=1000):
@@ -120,17 +118,14 @@ class Gamma(RegressionModel):
         n, k = X.shape
         X_batch, B_batch, T_batch = tf_utils.get_batch_placeholders((X, B, T))
 
-        alpha = tf.Variable(tf.zeros([k]), 'alpha')
-        beta = tf.Variable(tf.zeros([k]), 'beta')
-        a = tf.Variable(tf.zeros([]), 'a')
-        b = tf.Variable(tf.zeros([]), 'b')
+        alpha = tf.Variable(tf.zeros([k]), name='alpha')
+        beta = tf.Variable(tf.zeros([k]), name='beta')
+        a = tf.Variable(tf.zeros([]), name='a')
+        b = tf.Variable(tf.zeros([]), name='b')
         X_batch = tf.nn.dropout(X_batch, keep_prob=0.5)
         X_prod_alpha = tf.squeeze(tf.matmul(X_batch, tf.expand_dims(alpha, -1)), 1) + a
         X_prod_beta = tf.squeeze(tf.matmul(X_batch, tf.expand_dims(beta, -1)), 1) + b
-        log_k_var = tf.Variable(tf.constant(1.0, shape=[]), 'log_k')
-        X_prod_alpha = tf.squeeze(tf.matmul(X, tf.expand_dims(alpha, -1)), 1) + a
-        X_prod_beta = tf.squeeze(tf.matmul(X, tf.expand_dims(beta, -1)), 1) + b
-        k = tf.exp(log_k_var)
+        k = tf.Variable(2.0, name='k', trainable=False)
         lambd = tf.exp(X_prod_alpha)
         c = tf.sigmoid(X_prod_beta)
 
@@ -143,18 +138,33 @@ class Gamma(RegressionModel):
         LL_censored = tf.log((1-c) + c * (1 - cdf))
 
         LL = tf.reduce_sum(B_batch * LL_observed + (1 - B_batch) * LL_censored, 0)
+        feed_dict = {X_batch: X, B_batch: B, T_batch: T}
+
+        new_k = tf.placeholder(tf.float32, shape=[])
+        assign_k = tf.assign(k, new_k)
+
+        def update_k(sess):
+            import time
+            t0 = time.time()
+            # tf.igamma doesn't compute the gradient wrt a properly
+            # So let's just try small perturbations
+            k_value = sess.run(k)
+            res = {}
+            for k_mult in [0.99, 1.0, 1.01]:
+                sess.run(assign_k, feed_dict={new_k: k_value * k_mult})
+                res[k_value * k_mult] = sess.run(LL, feed_dict=feed_dict)
+            sess.run(assign_k, feed_dict={new_k: max(res.keys(), key=res.get)})
 
         with tf.Session() as sess:
-            feed_dict = {X_batch: X, B_batch: B, T_batch: T}
-            tf_utils.optimize(sess, LL_penalized, (alpha, beta, log_k_var), feed_dict)
+            tf_utils.optimize(sess, LL, feed_dict, update_callback=update_k)
             self.params = {
                 'alpha': sess.run(alpha),
                 'beta': sess.run(beta),
                 'a': sess.run(a),  # TODO: store hessian
                 'b': sess.run(b),  # TODO: store hessian
                 'k': sess.run(k),
-                'alpha_hessian': tf_utils.get_hessian(sess, LL_penalized, feed_dict, alpha),
-                'beta_hessian': tf_utils.get_hessian(sess, LL_penalized, feed_dict, beta),
+                'alpha_hessian': tf_utils.get_hessian(sess, LL, feed_dict, alpha),
+                'beta_hessian': tf_utils.get_hessian(sess, LL, feed_dict, beta),
             }
 
     def predict(self, x, t, ci=None, n=1000):

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -174,7 +174,7 @@ class Gamma(RegressionModel):
         return tf_utils.predict(expit(x_prod_beta) * gammainc(self.params['k'], numpy.multiply.outer(t, numpy.exp(x_prod_alpha))), ci)
 
     def predict_final(self, x, ci=None, n=1000):
-        x_prod_beta = tf_utils.sample_hessian(x, self.params['beta'], self.params['beta_hessian'], n, ci) + self.params['a']
+        x_prod_beta = tf_utils.sample_hessian(x, self.params['beta'], self.params['beta_hessian'], n, ci) + self.params['b']
         return tf_utils.predict(expit(x_prod_beta), ci)
 
     def predict_time(self, x, ci=None, n=1000):

--- a/convoys/single.py
+++ b/convoys/single.py
@@ -96,7 +96,7 @@ class Nonparametric(SingleModel):
             return tf.reduce_sum(count_observed * LL_observed + count_unobserved * LL_unobserved, 0)
 
         with tf.Session() as sess:
-            tf_utils.optimize(sess, get_LL(log_survived_until, log_survived_after, log_observed), (z, beta))
+            tf_utils.optimize(sess, get_LL(log_survived_until, log_survived_after, log_observed), (z, beta), {})
 
             # At this point, we're going to reparametrize the problem to be a function of log_survived_after
             # We can't do that with the original problem, since that would induce negative values of log_observed
@@ -112,9 +112,9 @@ class Nonparametric(SingleModel):
             # elements are almost zero.
             self.params = {
                 'beta': sess.run(beta),
-                'beta_std': tf_utils.get_hessian(sess, LL, beta) ** -0.5,
+                'beta_std': tf_utils.get_hessian(sess, LL, {}, beta) ** -0.5,
                 'z': sess.run(z),
-                'z_std': numpy.diag(tf_utils.get_hessian(sess, LL, z)) ** -0.5,  # TODO: seems inefficient
+                'z_std': numpy.diag(tf_utils.get_hessian(sess, LL, {}, z)) ** -0.5,  # TODO: seems inefficient
             }
             self.params['z_std'] = 0  # not sure what's up, will revisit this
 

--- a/convoys/single.py
+++ b/convoys/single.py
@@ -96,7 +96,7 @@ class Nonparametric(SingleModel):
             return tf.reduce_sum(count_observed * LL_observed + count_unobserved * LL_unobserved, 0)
 
         with tf.Session() as sess:
-            tf_utils.optimize(sess, get_LL(log_survived_until, log_survived_after, log_observed), (z, beta), {})
+            tf_utils.optimize(sess, get_LL(log_survived_until, log_survived_after, log_observed), {})
 
             # At this point, we're going to reparametrize the problem to be a function of log_survived_after
             # We can't do that with the original problem, since that would induce negative values of log_observed

--- a/convoys/single.py
+++ b/convoys/single.py
@@ -23,7 +23,10 @@ class KaplanMeier(SingleModel):
             self._ts.append(t)
             prod_s_terms *= 1 - d/n
             self._ss.append(prod_s_terms)
-            sum_var_terms += d / (n*(n-d))
+            try:
+                sum_var_terms += d / (n*(n-d))
+            except ZeroDivisionError:
+                sum_var_terms = float('inf')
             self._vs.append(1 / numpy.log(prod_s_terms)**2 * sum_var_terms)
             n -= 1
         self.get_j = lambda t: numpy.searchsorted(self._ts, t)

--- a/convoys/tf_utils.py
+++ b/convoys/tf_utils.py
@@ -40,14 +40,13 @@ def optimize(sess, target, placeholders, batch_size=1024, update_callback=None):
             sess.run(optimizer, feed_dict=feed_dict)
             cost += sess.run(target, feed_dict=feed_dict)
 
-        sys.stdout.write('step %6d (lr %6.6f): %14.3f%30s' % (step, learning_rate, cost, ''))
-        sys.stdout.write('\n' if step % 100 == 0 else '\r')
-        sys.stdout.flush()
-
         if cost > best_cost:
             best_cost, best_step = cost, step
         if step - best_step > 20:
             break
+        sys.stdout.write('step %6d (%6d since best): %14.3f%30s' % (step, step-best_step, cost, ''))
+        sys.stdout.write('\n' if step % 100 == 0 else '\r')
+        sys.stdout.flush()
         step += 1
 
         if update_callback:

--- a/convoys/tf_utils.py
+++ b/convoys/tf_utils.py
@@ -26,12 +26,8 @@ def optimize(sess, target, variables, placeholders, batch_size=1<<16):
     else:
         n = 1
 
-    dec_learning_rate = 1.0
-    step, best_step = 0, 0
-    best_cost = float('-inf')
-    while True:
-        inc_learning_rate = 10 ** (min(240, step)//40-6)
-        learning_rate = min(inc_learning_rate, dec_learning_rate)
+    learning_rate = 3e-4
+    for step in range(30000):
         cost = 0
         shuffled = sklearn.utils.shuffle(*placeholders.values())
         for i in range(0, n, batch_size):
@@ -42,15 +38,7 @@ def optimize(sess, target, variables, placeholders, batch_size=1<<16):
             feed_dict[learning_rate_input] = learning_rate
             sess.run(optimizer, feed_dict=feed_dict)
             cost += sess.run(target, feed_dict=feed_dict)
-        if cost > best_cost:
-            best_cost, best_step = cost, step
-        elif step - best_step > 40:
-            dec_learning_rate = learning_rate / 10
-            best_cost, best_step = float('-inf'), step
-        if learning_rate < 1e-6:
-            sys.stdout.write('\n')
-            break
-        step += 1
+
         sys.stdout.write('step %6d (lr %6.6f): %14.3f%30s' % (step, learning_rate, cost, ''))
         sys.stdout.write('\n' if step % 100 == 0 else '\r')
         sys.stdout.flush()

--- a/convoys/tf_utils.py
+++ b/convoys/tf_utils.py
@@ -27,7 +27,7 @@ def optimize(sess, target, placeholders, batch_size=1024, update_callback=None):
         n = 1
 
     best_cost, best_step, step = float('-inf'), 0, 0
-    learning_rate = 3e-4
+    learning_rate = 3e-3
     while True:
         cost = 0
         shuffled = sklearn.utils.shuffle(*placeholders.values())
@@ -46,7 +46,7 @@ def optimize(sess, target, placeholders, batch_size=1024, update_callback=None):
 
         if cost > best_cost:
             best_cost, best_step = cost, step
-        if step - best_step > 200:
+        if step - best_step > 20:
             break
         step += 1
 

--- a/convoys/tf_utils.py
+++ b/convoys/tf_utils.py
@@ -1,44 +1,52 @@
 import numpy
 import scipy.stats
+import sklearn.utils
 import sys
 import tensorflow as tf
 
 tf.logging.set_verbosity(3)
 
 
-def get_hessian(sess, f, param):
-    return sess.run(tf.hessians(-f, [param]))[0]
+def get_batch_placeholders(vs):
+    return [tf.placeholder(tf.float32, shape=((None,) + v.shape[1:])) for v in vs]
 
 
-def optimize(sess, target, variables):
+def get_hessian(sess, f, feed_dict, param):
+    return sess.run(tf.hessians(-f, [param]), feed_dict=feed_dict)[0]
+
+
+def optimize(sess, target, variables, placeholders, batch_size=1<<16):
     learning_rate_input = tf.placeholder(tf.float32, [])
-    optimizer = tf.train.AdamOptimizer(learning_rate_input).minimize(-target)
+    optimizer = tf.train.AdagradOptimizer(learning_rate_input).minimize(-target)
 
-    best_state_variables = [tf.Variable(tf.zeros(v.shape)) for v in variables]
-    store_best_state = [tf.assign(v, u) for (u, v) in zip(variables, best_state_variables)]
-    restore_best_state = [tf.assign(u, v) for (u, v) in zip(variables, best_state_variables)]
     sess.run(tf.global_variables_initializer())
 
-    best_step, step = 0, 0
-    dec_learning_rate = 1.0
-    best_cost = sess.run(target)
-    any_var_is_nan = tf.is_nan(tf.add_n([tf.reduce_sum(v) for v in variables]))
+    if placeholders:
+        n = int(list(placeholders.values())[0].shape[0])
+    else:
+        n = 1
 
+    dec_learning_rate = 1.0
+    step, best_step = 0, 0
+    best_cost = float('-inf')
     while True:
-        inc_learning_rate = 10**(min(step, 240)//40-6)
+        inc_learning_rate = 10 ** (min(240, step)//40-6)
         learning_rate = min(inc_learning_rate, dec_learning_rate)
-        sess.run(optimizer, feed_dict={learning_rate_input: learning_rate})
-        if sess.run(any_var_is_nan):
-            cost = float('-inf')
-        else:
-            cost = sess.run(target)
+        cost = 0
+        shuffled = sklearn.utils.shuffle(*placeholders.values())
+        for i in range(0, n, batch_size):
+            if placeholders:
+                feed_dict = {placeholder: v[i:min(i+batch_size, n)] for placeholder, v in zip(placeholders.keys(), shuffled)}
+            else:
+                feed_dict = {}
+            feed_dict[learning_rate_input] = learning_rate
+            sess.run(optimizer, feed_dict=feed_dict)
+            cost += sess.run(target, feed_dict=feed_dict)
         if cost > best_cost:
             best_cost, best_step = cost, step
-            sess.run(store_best_state)
-        elif str(cost) in ('-inf', 'nan') or step - best_step > 40:
-            sess.run(restore_best_state)
+        elif step - best_step > 40:
             dec_learning_rate = learning_rate / 10
-            best_step = step
+            best_cost, best_step = float('-inf'), step
         if learning_rate < 1e-6:
             sys.stdout.write('\n')
             break

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 matplotlib>=2.0.0
 numpy
 scipy
+sklearn
 seaborn==0.8.1
 tensorflow==1.6.0rc1

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -109,7 +109,7 @@ def test_gamma_regression_model(c=0.3, lambd=0.1, k=3.0, n=100000):
     model.fit(X, B, T)
     assert 0.95*c < model.predict_final([1]) < 1.05*c
     assert 0.90*k < model.params['k'] < 1.10*k
-    assert 0.90*lambd < numpy.exp(model.params['alpha']) < 1.10*lambd
+    assert 0.90*lambd < numpy.exp(model.params['a'] + model.params['alpha']) < 1.10*lambd
     assert 0.80*k/lambd < model.predict_time([1]) < 1.20*k/lambd
 
 

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -53,7 +53,7 @@ def test_exponential_regression_model(c=0.3, lambd=0.1, n=100000):
 
 @flaky.flaky
 def test_weibull_regression_model(cs=[0.3, 0.5, 0.7], lambd=0.1, k=0.5, n=100000):
-    X = numpy.array([[1] + [r % len(cs) == j for j in range(len(cs))] for r in range(n)])
+    X = numpy.array([[r % len(cs) == j for j in range(len(cs))] for r in range(n)])
     C = numpy.array([bool(random.random() < cs[r % len(cs)]) for r in range(n)])
     N = scipy.stats.uniform.rvs(scale=5./lambd, size=(n,))
     E = numpy.array([sample_weibull(k, lambd) for r in range(n)])
@@ -63,7 +63,7 @@ def test_weibull_regression_model(cs=[0.3, 0.5, 0.7], lambd=0.1, k=0.5, n=100000
     model.fit(X, B, T)
 
     # Validate shape of results
-    x = numpy.ones((len(cs)+1,))
+    x = numpy.ones((len(cs),))
     assert model.predict_final(x).shape == ()
     assert model.predict_final(x, ci=0.95).shape == (3,)
     assert model.predict(x, 1).shape == ()
@@ -73,7 +73,7 @@ def test_weibull_regression_model(cs=[0.3, 0.5, 0.7], lambd=0.1, k=0.5, n=100000
 
     # Check results
     for r, c in enumerate(cs):
-        x = [1] + [int(r == j) for j in range(len(cs))]
+        x = [int(r == j) for j in range(len(cs))]
         assert 0.95 * c < model.predict_final(x) < 1.05 * c
         expected_time = 1./lambd * scipy.special.gamma(1 + 1/k)
         assert 0.80*expected_time < model.predict_time(x) < 1.20*expected_time


### PR DESCRIPTION
This changes a bunch of stuff

* Minibatches for faster convergence (although it makes every epoch a lot slower). This also gets rid of the checks for `nan` etc
* Dropout rather than regression. Dropout on the inputs.
* Fit an intercept to the regression model as a separate parameter just so that it's not affected by dropout
* Turns out `tf.igamma` has a bug in the gradient wrt `a` (I'll open an issue with `tensorflow` later). Rather than setting it using gradient descent, do a minor perturbation after each step
* Once gamma was fixed, turns out we can have a much simpler learning rate scheme, not save snapshots etc.