### PR TITLE
remove predict_final and predict_time

### DIFF
--- a/convoys/__init__.py
+++ b/convoys/__init__.py
@@ -112,15 +112,17 @@ def plot_cohorts(data, t_max=None, title=None, group_min_size=0, max_groups=100,
 
         if ci is not None:
             p_y, p_y_lo, p_y_hi = m.predict(j, t, ci=ci).T
-            p_y_final, p_y_lo_final, p_y_hi_final = m.predict_final(j, ci=0.95)
-            label += ' projected: %.2f%% (%.2f%% - %.2f%%)' % (100.*p_y_final, 100.*p_y_lo_final, 100.*p_y_hi_final)
+            p_y_final, p_y_lo_final, p_y_hi_final = m.predict(j, float('inf'), ci=0.95)
+            if str(p_y_final) != 'nan':
+                label += ' projected: %.2f%% (%.2f%% - %.2f%%)' % (100.*p_y_final, 100.*p_y_lo_final, 100.*p_y_hi_final)
             result.append((group, p_y_final, p_y_lo_final, p_y_hi_final))
             pyplot.plot(t, 100. * p_y, color=color, linewidth=1.5, alpha=0.7, label=label)
             pyplot.fill_between(t, 100. * p_y_lo, 100. * p_y_hi, color=color, alpha=0.2)
         else:
             p_y = m.predict(j, t).T
-            p_y_final = m.predict_final(j, ci=None)
-            label += ' projected: %.2f%%' % (100.*p_y_final,)
+            p_y_final = m.predict(j, float('inf'), ci=None)
+            if str(p_y_final) != 'nan':
+                label += ' projected: %.2f%%' % (100.*p_y_final,)
             result.append((group, p_y_final))
             pyplot.plot(t, 100. * p_y, color=color, linewidth=1.5, alpha=0.7, label=label)
 

--- a/convoys/multi.py
+++ b/convoys/multi.py
@@ -26,12 +26,6 @@ class RegressionToMulti(MultiModel):
     def predict(self, group, t, *args, **kwargs):
         return self.base_model.predict(self._get_x(group), t, *args, **kwargs)
 
-    def predict_final(self, group, *args, **kwargs):
-        return self.base_model.predict_final(self._get_x(group), *args, **kwargs)
-
-    def predict_time(self, group, *args, **kwargs):
-        return self.base_model.predict_time(self._get_x(group), *args, **kwargs)
-
 
 class SingleToMulti(MultiModel):
     def __init__(self, *args, **kwargs):
@@ -48,12 +42,6 @@ class SingleToMulti(MultiModel):
 
     def predict(self, group, t, *args, **kwargs):
         return self._group2model[group].predict(t, *args, **kwargs)
-
-    def predict_final(self, group, *args, **kwargs):
-        return self._group2model[group].predict_final(*args, **kwargs)
-
-    def predict_time(self, group, *args, **kwargs):
-        return self._group2model[group].predict_time(*args, **kwargs)
 
 
 class Exponential(RegressionToMulti):

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -71,14 +71,6 @@ class Exponential(RegressionModel):
         b = LinearCombination.sample(self.params['b'], x, ci, n)
         return tf_utils.predict(expit(b) * (1 - numpy.exp(numpy.multiply.outer(-t, numpy.exp(a)))), ci)
 
-    def predict_final(self, x, ci=None, n=1000):
-        b = LinearCombination.sample(self.params['b'], x, ci, n)
-        return tf_utils.predict(expit(b), ci)
-
-    def predict_time(self, x, ci=None, n=1000):
-        a = LinearCombination.sample(self.params['a'], x, ci, n)
-        return tf_utils.predict(1./numpy.exp(a), ci)
-
 
 class Weibull(RegressionModel):
     def fit(self, X, B, T):
@@ -117,14 +109,6 @@ class Weibull(RegressionModel):
         a = LinearCombination.sample(self.params['a'], x, ci, n)
         b = LinearCombination.sample(self.params['b'], x, ci, n)
         return tf_utils.predict(expit(b) * (1 - numpy.exp(-numpy.multiply.outer(t, numpy.exp(a))**self.params['k'])), ci)
-
-    def predict_final(self, x, ci=None, n=1000):
-        b = LinearCombination.sample(self.params['b'], x, ci, n)
-        return tf_utils.predict(expit(b), ci)
-
-    def predict_time(self, x, ci=None, n=1000):
-        a = LinearCombination.sample(self.params['a'], x, ci, n)
-        return tf_utils.predict(1./numpy.exp(a) * gamma(1 + 1./self.params['k']), ci)
 
 
 class Gamma(RegressionModel):
@@ -176,11 +160,3 @@ class Gamma(RegressionModel):
         a = LinearCombination.sample(self.params['a'], x, ci, n)
         b = LinearCombination.sample(self.params['b'], x, ci, n)
         return tf_utils.predict(expit(b) * gammainc(self.params['k'], numpy.multiply.outer(t, numpy.exp(a))), ci)
-
-    def predict_final(self, x, ci=None, n=1000):
-        b = LinearCombination.sample(self.params['b'], x, ci, n)
-        return tf_utils.predict(expit(b), ci)
-
-    def predict_time(self, x, ci=None, n=1000):
-        a = LinearCombination.sample(self.params['a'], x, ci, n)
-        return tf_utils.predict(self.params['k']/numpy.exp(a), ci)

--- a/convoys/single.py
+++ b/convoys/single.py
@@ -43,6 +43,7 @@ class KaplanMeier(SingleModel):
             return 1 - self._ss[j]
 
     def predict(self, t, ci=None):
+        t = numpy.array(t)
         res = numpy.zeros(t.shape + (3,) if ci else t.shape)
         for indexes, value in numpy.ndenumerate(t):
             j = self.get_j(value)
@@ -52,9 +53,6 @@ class KaplanMeier(SingleModel):
             else:
                 res[indexes] = self._get_value_at(j, ci)
         return res
-
-    def predict_final(self, ci=None):
-        return self._get_value_at(len(self._ts)-1, ci)
 
 
 class Nonparametric(SingleModel):
@@ -140,10 +138,3 @@ class Nonparametric(SingleModel):
             j = self.get_j(value)
             res[indexes] = m[j]
         return res
-
-    def predict_final(self, ci=None, n=1000):
-        if ci:
-            betas = numpy.random.normal(self.params['beta'], self.params['beta_std'], n)
-            return tf_utils.predict(expit(betas), ci)
-        else:
-            return expit(self.params['beta'])


### PR DESCRIPTION
This wasn't super useful and caused a bunch of clutter. Also often incorrect.

Should probably be renamed "cdf".

As a next step, will add some sort of "ppf" method which returns the inverse of the "cdf" – this will be useful for sampling events.