### PR TITLE
enable python on hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+flake8:
+  enabled: true


### PR DESCRIPTION
Turns out Hound doesn't enable Python by default.