### PR TITLE
lower batch size

### DIFF
--- a/convoys/tf_utils.py
+++ b/convoys/tf_utils.py
@@ -11,7 +11,7 @@ def get_batch_placeholders(vs):
 
 
 def optimize(sess, target_batch, target_global=None, placeholders={},
-             batch_size=1024, update_callback=None):
+             batch_size=128, update_callback=None):
     if placeholders:
         n = int(list(placeholders.values())[0].shape[0])
         indexes = list(range(n))


### PR DESCRIPTION
this seems to improve convergence for some real world data i have

not sure why/if it's so much slower, should figure out if piping it through `feed_dict` is the wrong way to do minibatches