### PR TITLE
prevent regression.py from producing garbage output in jupyter notebooks

### DIFF
--- a/convoys/multi.py
+++ b/convoys/multi.py
@@ -14,7 +14,7 @@ class RegressionToMulti(MultiModel):
     def __init__(self, *args, **kwargs):
         self.base_model = self._base_model_cls(*args, **kwargs)
 
-    def fit(self, G, B, T):
+    def fit(self, G, B, T, verbose=False):
         ''' Fits the model
 
         :param G: numpy vector of shape :math:`n`
@@ -27,7 +27,7 @@ class RegressionToMulti(MultiModel):
         X = numpy.zeros((n, self._n_groups), dtype=numpy.bool)
         for i, group in enumerate(G):
             X[i,group] = 1
-        self.base_model.fit(X, B, T)
+        self.base_model.fit(X, B, T, verbose=verbose)
 
     def _get_x(self, group):
         x = numpy.zeros(self._n_groups)
@@ -45,7 +45,7 @@ class SingleToMulti(MultiModel):
     def __init__(self, *args, **kwargs):
         self.base_model_init = lambda: self._base_model_cls(*args, **kwargs)
 
-    def fit(self, G, B, T):
+    def fit(self, G, B, T, verbose=False):
         ''' Fits the model
 
         :param G: numpy vector of shape :math:`n`
@@ -58,7 +58,7 @@ class SingleToMulti(MultiModel):
         self._group2model = {}
         for g, BT in group2bt.items():
             self._group2model[g] = self.base_model_init()
-            self._group2model[g].fit([b for b, t in BT], [t for b, t in BT])
+            self._group2model[g].fit([b for b, t in BT], [t for b, t in BT], verbose=verbose)
 
     def cdf(self, group, t, *args, **kwargs):
         return self._group2model[group].cdf(t, *args, **kwargs)

--- a/convoys/plotting.py
+++ b/convoys/plotting.py
@@ -16,7 +16,19 @@ _models = {
 
 def plot_cohorts(G, B, T, t_max=None, model='kaplan-meier',
                  ci=None, plot_kwargs={}, plot_ci_kwargs={},
-                 groups=None, specific_groups=None):
+                 groups=None, specific_groups=None, verbose=False):
+    '''
+    Generate cohort estimation plots based on fitted models
+
+    :param t_max: int max time horizion (x axis)
+    :param model: convoys.multi.MultiModel model type
+    :param ci: int confidence interval range of model
+    :param plot_kwargs: line plotting kwargs
+    :param plot_ci_kwargs: confidence interval kwargs
+    :param groups: array or group names
+    :parm specific groups: subset of groups that will be plotted
+    :param verbose: bool write model progress to stdout
+    '''
 
     if model not in _models.keys():
         if not isinstance(model, convoys.multi.MultiModel):
@@ -32,7 +44,7 @@ def plot_cohorts(G, B, T, t_max=None, model='kaplan-meier',
     if not isinstance(model, convoys.multi.MultiModel):
         # Fit model
         m = _models[model](ci=bool(ci))
-        m.fit(G, B, T)
+        m.fit(G, B, T, verbose=verbose)
     else:
         m = model
 

--- a/convoys/single.py
+++ b/convoys/single.py
@@ -12,7 +12,7 @@ class SingleModel:
 
 class KaplanMeier(SingleModel):
     ''' Implementation of the Kaplan-Meier nonparametric method. '''
-    def fit(self, B, T):
+    def fit(self, B, T, verbose=False):
         ''' Fits the model
 
         :param B: numpy vector of shape :math:`n`

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -253,10 +253,14 @@ def test_plot_cohorts_model():
     with pytest.raises(Exception):
         convoys.plotting.plot_cohorts(G, B, T, model='bad', groups=groups)
 
+    #test for when specific group is not a subset of groups
     with pytest.raises(Exception):
         convoys.plotting.plot_cohorts(G, B, T, model=model, groups=groups,
                                       specific_groups=['Nonsense'])
-
+    #test for verbose == True 
+    with pytest.raises(Exception):
+        convoys.plotting.plot_cohorts(G, B, T, model=model, groups=groups,
+                                      verbose=True)
 
 @flaky.flaky
 def test_plot_cohorts_kaplan_meier():


### PR DESCRIPTION
PR for #93 

Check if user is calling `GeneralizedGamma` within a Jupyter Notebook and suppress `sys.stdout.flush()` if true. Still need to think about how to replicate the carriage return so we can see the updating as the model fits.

Current output:  
![image](https://user-images.githubusercontent.com/13262878/56433467-f7027900-629e-11e9-81e9-41046d4eab49.png)

PR output:
![image](https://user-images.githubusercontent.com/13262878/56433540-26b18100-629f-11e9-83a9-e5f1f06732c1.png)

