### PR TITLE
Use more accurate gamma derivatives

### DIFF
--- a/convoys/gamma.py
+++ b/convoys/gamma.py
@@ -41,8 +41,6 @@ def gammainc(k, x):
 
 
 delta = 1e-6
-gammainc = primitive(_scipy_gammainc)
-
 
 defvjp(
     gammainc,


### PR DESCRIPTION
I too have struggled with gamma derivatives! This PR is my current best effort, so I can share it with convoys. 

1. Use an analytical solution for derivative w.r.t the x variable
2. Use a O(h^4) order finite difference method w.r.t. the a (k) variable. This has much better stability in the second derivative too. 

I've also included `gammaincc`, as `gammaincc=1-gammainc` and you have `1-gammainc` in your code, so this is a possible small convenience. 