### PR TITLE
mock progressbar, make sure sphinx docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-install:
-  - pip install -U coveralls flaky pytest pytest-cov sphinx
-  - pip install .
 script:
+  - pip install -U sphinx
+  - sphinx-build -M html docs/ docs/_build/ -W  # Try building it before installing the rest, should work
+  - pip install -U coveralls flaky pytest pytest-cov
+  - pip install .
   - py.test -s -v --cov=convoys .
-  - sphinx-build -M html docs/ docs/_build/ -W
 after_success:
   - coveralls

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ html_sidebars = {
 
 # Make it possible to build docs without dependencies
 autodoc_mock_imports = ['autograd', 'autograd_gamma', 'emcee', 'matplotlib',
-                        'numpy', 'pandas', 'scipy']
+                        'numpy', 'pandas', 'progressbar', 'scipy']
 
 # -- Extension configuration -------------------------------------------------
 


### PR DESCRIPTION
Current docs are broken at https://better.engineering/convoys/

The reason is that progressbar isn't installed when sphinx runs

Fixing travis so that sphinx properly raises an error if it fails