### PR TITLE
add cdf_posteriori to return M, MCMC samples

### DIFF
--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -278,20 +278,16 @@ class GeneralizedGamma(RegressionModel):
             'beta': data[6+n_features:6+2*n_features].T,
         } for k, data in result.items()}
 
-    def cdf(self, x, t, ci=None):
+    def cdf_posteriori(self, x, t, ci=None):
         '''Returns the value of the cumulative distribution function
-        for a fitted model. TODO: this should probably be renamed
-        "predict" in the future to follow the scikit-learn convention.
+        for a fitted model.
 
         :param x: feature vector (or matrix)
         :param t: time
         :param ci: if this is provided, and the model was fit with
-            `ci = True`, then the return value will contain one more
-            dimension, and the last dimension will have size 3,
-            containing the mean, the lower bound of the confidence
-            interval, and the upper bound of the confidence interval.
-            If this is not provided, then the max a posteriori
-            prediction will be used.
+            `ci = True`, then the return value will be the trace
+            samples generated via the MCMC steps. If this is not 
+            provided, then the max a posteriori prediction will be used.
         '''
         x = numpy.array(x)
         t = numpy.array(t)
@@ -309,7 +305,25 @@ class GeneralizedGamma(RegressionModel):
         M = c * gammainc(
             params['k'],
             (t*lambd)**params['p'])
+        
+        return M
 
+    def cdf(self, x, t, ci=None):
+        '''Returns the value of the cumulative distribution function
+        for a fitted model. TODO: this should probably be renamed
+        "predict" in the future to follow the scikit-learn convention.
+
+        :param x: feature vector (or matrix)
+        :param t: time
+        :param ci: if this is provided, and the model was fit with
+            `ci = True`, then the return value will contain one more
+            dimension, and the last dimension will have size 3,
+            containing the mean, the lower bound of the confidence
+            interval, and the upper bound of the confidence interval.
+            If this is not provided, then the max a posteriori
+            prediction will be used.
+        '''
+        M = self.cdf_posteriori(x, t, ci)
         if not ci:
             return M
         else:

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -286,7 +286,7 @@ class GeneralizedGamma(RegressionModel):
         :param t: time
         :param ci: if this is provided, and the model was fit with
             `ci = True`, then the return value will be the trace
-            samples generated via the MCMC steps. If this is not 
+            samples generated via the MCMC steps. If this is not
             provided, then the max a posteriori prediction will be used.
         '''
         x = numpy.array(x)
@@ -305,7 +305,7 @@ class GeneralizedGamma(RegressionModel):
         M = c * gammainc(
             params['k'],
             (t*lambd)**params['p'])
-        
+
         return M
 
     def cdf(self, x, t, ci=None):


### PR DESCRIPTION
Added `cdf_posteriori` function so that the `M` cdf trace is available in full rather then only as its mean, and high and low CI estimates. 