### PR TITLE
Rename the cdf method to predict to be more in line with scikit-learn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
   - "3.7"
 script:
-  - pip install -U sphinx
+  - pip install -U sphinx deprecated
   - sphinx-build -M html docs/ docs/_build/ -W  # Try building it before installing the rest, should work
   - pip install -U coveralls flaky pytest pytest-cov
   - pip install .

--- a/convoys/multi.py
+++ b/convoys/multi.py
@@ -44,7 +44,7 @@ class RegressionToMulti(MultiModel):
     def rvs(self, group, *args, **kwargs):
         return self.base_model.rvs(self._get_x(group), *args, **kwargs)
 
-    @deprecated(version='0.1.8',
+    @deprecated(version='0.2.0',
                 reason='Use :meth:`predict` or :meth:`predict_ci` instead.')
     def cdf(self, group, t, ci=None):
         '''Returns the predicted values.'''
@@ -79,7 +79,7 @@ class SingleToMulti(MultiModel):
     def predict_ci(self, group, t, ci):
         return self._group2model[group].predict_ci(t, ci)
 
-    @deprecated(version='0.1.8',
+    @deprecated(version='0.2.0',
                 reason='Use :meth:`predict` or :meth:`predict_ci` instead')
     def cdf(self, group, t, ci=None):
         '''Returns the predicted values.'''

--- a/convoys/multi.py
+++ b/convoys/multi.py
@@ -1,4 +1,4 @@
-from deprecated import deprecated
+from deprecated.sphinx import deprecated
 import numpy
 from convoys import regression
 from convoys import single
@@ -41,8 +41,9 @@ class RegressionToMulti(MultiModel):
     def rvs(self, group, *args, **kwargs):
         return self.base_model.rvs(self._get_x(group), *args, **kwargs)
 
-    @deprecated(version='0.1.8', reason='Use the `predict` method instead')
+    @deprecated(version='0.1.8', reason='Has been renamed to :meth:`predict`')
     def cdf(self, *args, **kwargs):
+        '''Returns the predicted values.'''
         return self.predict(*args, **kwargs)
 
 
@@ -68,8 +69,9 @@ class SingleToMulti(MultiModel):
     def predict(self, group, t, *args, **kwargs):
         return self._group2model[group].predict(t, *args, **kwargs)
 
-    @deprecated(version='0.1.8', reason='Use the `predict` method instead')
+    @deprecated(version='0.1.8', reason='Has been renamed to :meth:`predict`')
     def cdf(self, *args, **kwargs):
+        '''Returns the predicted values.'''
         return self.predict(*args, **kwargs)
 
 

--- a/convoys/multi.py
+++ b/convoys/multi.py
@@ -35,16 +35,23 @@ class RegressionToMulti(MultiModel):
         x[group] = 1
         return x
 
-    def predict(self, group, *args, **kwargs):
-        return self.base_model.predict(self._get_x(group), *args, **kwargs)
+    def predict(self, group, t):
+        return self.base_model.predict(self._get_x(group), t)
+
+    def predict_ci(self, group, t, ci):
+        return self.base_model.predict_ci(self._get_x(group), t, ci)
 
     def rvs(self, group, *args, **kwargs):
         return self.base_model.rvs(self._get_x(group), *args, **kwargs)
 
-    @deprecated(version='0.1.8', reason='Has been renamed to :meth:`predict`')
-    def cdf(self, *args, **kwargs):
+    @deprecated(version='0.1.8',
+                reason='Use :meth:`predict` or :meth:`predict_ci` instead.')
+    def cdf(self, group, t, ci=None):
         '''Returns the predicted values.'''
-        return self.predict(*args, **kwargs)
+        if ci is not None:
+            return self.predict_ci(group, t, ci)
+        else:
+            return self.predict(group, t)
 
 
 class SingleToMulti(MultiModel):
@@ -66,13 +73,20 @@ class SingleToMulti(MultiModel):
             self._group2model[g] = self.base_model_init()
             self._group2model[g].fit([b for b, t in BT], [t for b, t in BT])
 
-    def predict(self, group, t, *args, **kwargs):
-        return self._group2model[group].predict(t, *args, **kwargs)
+    def predict(self, group, t):
+        return self._group2model[group].predict(t)
 
-    @deprecated(version='0.1.8', reason='Has been renamed to :meth:`predict`')
-    def cdf(self, *args, **kwargs):
+    def predict_ci(self, group, t, ci):
+        return self._group2model[group].predict_ci(t, ci)
+
+    @deprecated(version='0.1.8',
+                reason='Use :meth:`predict` or :meth:`predict_ci` instead')
+    def cdf(self, group, t, ci=None):
         '''Returns the predicted values.'''
-        return self.predict(*args, **kwargs)
+        if ci is not None:
+            return self.predict_ci(group, t, ci)
+        else:
+            return self.predict(group, t)
 
 
 class Exponential(RegressionToMulti):

--- a/convoys/multi.py
+++ b/convoys/multi.py
@@ -1,3 +1,4 @@
+from deprecated import deprecated
 import numpy
 from convoys import regression
 from convoys import single
@@ -34,11 +35,15 @@ class RegressionToMulti(MultiModel):
         x[group] = 1
         return x
 
-    def cdf(self, group, *args, **kwargs):
-        return self.base_model.cdf(self._get_x(group), *args, **kwargs)
+    def predict(self, group, *args, **kwargs):
+        return self.base_model.predict(self._get_x(group), *args, **kwargs)
 
     def rvs(self, group, *args, **kwargs):
         return self.base_model.rvs(self._get_x(group), *args, **kwargs)
+
+    @deprecated(version='0.1.8', reason='Use the `predict` method instead')
+    def cdf(self, *args, **kwargs):
+        return self.predict(*args, **kwargs)
 
 
 class SingleToMulti(MultiModel):
@@ -60,8 +65,12 @@ class SingleToMulti(MultiModel):
             self._group2model[g] = self.base_model_init()
             self._group2model[g].fit([b for b, t in BT], [t for b, t in BT])
 
-    def cdf(self, group, t, *args, **kwargs):
-        return self._group2model[group].cdf(t, *args, **kwargs)
+    def predict(self, group, t, *args, **kwargs):
+        return self._group2model[group].predict(t, *args, **kwargs)
+
+    @deprecated(version='0.1.8', reason='Use the `predict` method instead')
+    def cdf(self, *args, **kwargs):
+        return self.predict(*args, **kwargs)
 
 
 class Exponential(RegressionToMulti):

--- a/convoys/plotting.py
+++ b/convoys/plotting.py
@@ -81,7 +81,7 @@ def plot_cohorts(G, B, T, t_max=None, model='kaplan-meier',
         label = label_fmt % dict(group=group, n=n, k=k)
 
         if ci is not None:
-            p_y, p_y_lo, p_y_hi = m.predict(j, t, ci=ci).T
+            p_y, p_y_lo, p_y_hi = m.predict_ci(j, t, ci=ci).T
             merged_plot_ci_kwargs = {'alpha': 0.2}
             merged_plot_ci_kwargs.update(plot_ci_kwargs)
             p = ax.fill_between(t, 100. * p_y_lo, 100. * p_y_hi,

--- a/convoys/plotting.py
+++ b/convoys/plotting.py
@@ -81,14 +81,14 @@ def plot_cohorts(G, B, T, t_max=None, model='kaplan-meier',
         label = label_fmt % dict(group=group, n=n, k=k)
 
         if ci is not None:
-            p_y, p_y_lo, p_y_hi = m.cdf(j, t, ci=ci).T
+            p_y, p_y_lo, p_y_hi = m.predict(j, t, ci=ci).T
             merged_plot_ci_kwargs = {'alpha': 0.2}
             merged_plot_ci_kwargs.update(plot_ci_kwargs)
             p = ax.fill_between(t, 100. * p_y_lo, 100. * p_y_hi,
                                 **merged_plot_ci_kwargs)
             color = p.get_facecolor()[0]  # reuse color for the line
         else:
-            p_y = m.cdf(j, t).T
+            p_y = m.predict(j, t).T
             color = None
 
         merged_plot_kwargs = {'color': color, 'linewidth': 1.5,

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -362,7 +362,7 @@ class GeneralizedGamma(RegressionModel):
 
         return B, C
 
-    @deprecated(version='0.1.8',
+    @deprecated(version='0.2.0',
                 reason='Use :meth:`predict` or :meth:`predict_ci` instead.')
     def cdf(self, x, t, ci=False):
         '''Returns the predicted values.'''
@@ -371,7 +371,7 @@ class GeneralizedGamma(RegressionModel):
         else:
             return self.predict(x, t)
 
-    @deprecated(version='0.1.8',
+    @deprecated(version='0.2.0',
                 reason='Use :meth:`predict_posteriori` instead.')
     def cdf_posteriori(self, x, t):
         '''Returns the a posterior distribution of the predicted values.'''

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -1,7 +1,7 @@
 from convoys import autograd_scipy_monkeypatch  # NOQA
 import autograd
 from autograd_gamma import gammainc
-from deprecated import deprecated
+from deprecated.sphinx import deprecated
 import emcee
 import numpy
 from scipy.special import gammaincinv
@@ -311,8 +311,7 @@ class GeneralizedGamma(RegressionModel):
 
     def predict(self, x, t, ci=None):
         '''Returns the value of the cumulative distribution function
-        for a fitted model. TODO: this should probably be renamed
-        "predict" in the future to follow the scikit-learn convention.
+        for a fitted model.
 
         :param x: feature vector (or matrix)
         :param t: time
@@ -367,13 +366,14 @@ class GeneralizedGamma(RegressionModel):
 
         return B, C
 
-    @deprecated(version='0.1.8', reason='Use the `predict` method instead')
+    @deprecated(version='0.1.8', reason='Has been renamed to :meth:`predict`')
     def cdf(self, *args, **kwargs):
+        '''Returns the predicted values.'''
         return self.predict(*args, **kwargs)
 
-    @deprecated(version='0.1.8',
-                reason='Use the `predict_posteriori` method instead')
+    @deprecated(version='0.1.8', reason='Has been renamed to :meth:`predict`')
     def cdf_posteriori(self, *args, **kwargs):
+        '''Returns the predicted values.'''
         return self.predict_posteriori(*args, **kwargs)
 
 

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -289,7 +289,7 @@ class GeneralizedGamma(RegressionModel):
             params['k'],
             (t*lambd)**params['p'])
 
-        return M        
+        return M
 
     def predict_posteriori(self, x, t):
         ''' Returns the trace samples generated via the MCMC steps.
@@ -371,7 +371,8 @@ class GeneralizedGamma(RegressionModel):
         else:
             return self.predict(x, t)
 
-    @deprecated(version='0.1.8', reason='Use :meth:`predict_posteriori` instead.')
+    @deprecated(version='0.1.8',
+                reason='Use :meth:`predict_posteriori` instead.')
     def cdf_posteriori(self, x, t):
         '''Returns the a posterior distribution of the predicted values.'''
         return self.predict_posteriori(x, t)

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -1,6 +1,7 @@
 from convoys import autograd_scipy_monkeypatch  # NOQA
 import autograd
 from autograd_gamma import gammainc
+from deprecated import deprecated
 import emcee
 import numpy
 from scipy.special import gammaincinv
@@ -76,7 +77,7 @@ class GeneralizedGamma(RegressionModel):
 
     :param ci: boolean, defaults to False. Whether to use MCMC to
         sample from the posterior so that a confidence interval can be
-        estimated later (see :meth:`cdf`).
+        estimated later (see :meth:`predict`).
     :param hierarchical: boolean denoting whether we have a (Normal) prior
         on the alpha and beta parameters to regularize. The variance of
         the normal distribution is in itself assumed to be an inverse
@@ -278,7 +279,7 @@ class GeneralizedGamma(RegressionModel):
             'beta': data[6+n_features:6+2*n_features].T,
         } for k, data in result.items()}
 
-    def cdf_posteriori(self, x, t, ci=None):
+    def predict_posteriori(self, x, t, ci=None):
         '''Returns the value of the cumulative distribution function
         for a fitted model.
 
@@ -308,7 +309,7 @@ class GeneralizedGamma(RegressionModel):
 
         return M
 
-    def cdf(self, x, t, ci=None):
+    def predict(self, x, t, ci=None):
         '''Returns the value of the cumulative distribution function
         for a fitted model. TODO: this should probably be renamed
         "predict" in the future to follow the scikit-learn convention.
@@ -323,7 +324,7 @@ class GeneralizedGamma(RegressionModel):
             If this is not provided, then the max a posteriori
             prediction will be used.
         '''
-        M = self.cdf_posteriori(x, t, ci)
+        M = self.predict_posteriori(x, t, ci)
         if not ci:
             return M
         else:
@@ -334,8 +335,10 @@ class GeneralizedGamma(RegressionModel):
             return numpy.stack((y, y_lo, y_hi), axis=-1)
 
     def rvs(self, x, n_curves=1, n_samples=1, T=None):
-        # Samples values from this distribution
-        # T is optional and means we already observed non-conversion until T
+        ''' Samples values from this distribution
+
+        T is optional and means we already observed non-conversion until T
+        '''
         assert self._ci  # Need to be fit with MCMC
         if T is None:
             T = numpy.zeros((n_curves, n_samples))
@@ -363,6 +366,14 @@ class GeneralizedGamma(RegressionModel):
             C[i][~B[i]] = 0
 
         return B, C
+
+    @deprecated(version='0.1.8', reason='Use the `predict` method instead')
+    def cdf(self, *args, **kwargs):
+        return self.predict(*args, **kwargs)
+
+    @deprecated(version='0.1.8', reason='Use the `predict_posteriori` method instead')
+    def cdf_posteriori(self, *args, **kwargs):
+        return self.predict_posteriori(*args, **kwargs)
 
 
 class Exponential(GeneralizedGamma):

--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -371,7 +371,8 @@ class GeneralizedGamma(RegressionModel):
     def cdf(self, *args, **kwargs):
         return self.predict(*args, **kwargs)
 
-    @deprecated(version='0.1.8', reason='Use the `predict_posteriori` method instead')
+    @deprecated(version='0.1.8',
+                reason='Use the `predict_posteriori` method instead')
     def cdf_posteriori(self, *args, **kwargs):
         return self.predict_posteriori(*args, **kwargs)
 

--- a/convoys/single.py
+++ b/convoys/single.py
@@ -1,3 +1,4 @@
+from deprecated import deprecated
 import numpy
 from scipy.special import expit, logit
 import scipy.stats
@@ -66,7 +67,7 @@ class KaplanMeier(SingleModel):
         else:
             return 1 - self._ss[j]
 
-    def cdf(self, t, ci=None):
+    def predict(self, t, ci=None):
         t = numpy.array(t)
         res = numpy.zeros(t.shape + (3,) if ci else t.shape)
         for indexes, value in numpy.ndenumerate(t):
@@ -77,3 +78,7 @@ class KaplanMeier(SingleModel):
             else:
                 res[indexes] = self._get_value_at(j, ci)
         return res
+
+    @deprecated(version='0.1.8', reason='Use the `predict` method instead')
+    def cdf(self, *args, **kwargs):
+        return self.predict(*args, **kwargs)

--- a/convoys/single.py
+++ b/convoys/single.py
@@ -1,4 +1,4 @@
-from deprecated import deprecated
+from deprecated.sphinx import deprecated
 import numpy
 from scipy.special import expit, logit
 import scipy.stats
@@ -68,6 +68,7 @@ class KaplanMeier(SingleModel):
             return 1 - self._ss[j]
 
     def predict(self, t, ci=None):
+        '''Returns the predicted values.'''
         t = numpy.array(t)
         res = numpy.zeros(t.shape + (3,) if ci else t.shape)
         for indexes, value in numpy.ndenumerate(t):
@@ -79,6 +80,7 @@ class KaplanMeier(SingleModel):
                 res[indexes] = self._get_value_at(j, ci)
         return res
 
-    @deprecated(version='0.1.8', reason='Use the `predict` method instead')
+    @deprecated(version='0.1.8', reason='Has been renamed to :meth:`predict`')
     def cdf(self, *args, **kwargs):
+        '''Returns the predicted values.'''
         return self.predict(*args, **kwargs)

--- a/convoys/single.py
+++ b/convoys/single.py
@@ -87,7 +87,7 @@ class KaplanMeier(SingleModel):
                     )
         return res
 
-    @deprecated(version='0.1.8',
+    @deprecated(version='0.2.0',
                 reason='Use :meth:`predict` or :meth:`predict_ci` instead.')
     def cdf(self, t, ci=None):
         '''Returns the predicted values.'''

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name='convoys',
       install_requires=[
           'autograd',
           'autograd-gamma>=0.2.0',
+          'deprecated',
           'emcee>=3.0.0',
           'matplotlib>=2.0.0',
           'pandas>=0.24.0',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ or
 '''
 
 setup(name='convoys',
-      version='0.1.7',
+      version='0.1.8',
       description='Fit machine learning models to predict conversion using Weibull and Gamma distributions',
       long_description=long_description,
       url='https://better.engineering/convoys',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ or
 '''
 
 setup(name='convoys',
-      version='0.1.8',
+      version='0.2.0',
       description='Fit machine learning models to predict conversion using Weibull and Gamma distributions',
       long_description=long_description,
       url='https://better.engineering/convoys',

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -53,7 +53,7 @@ def test_kaplan_meier_model():
     )
     m = convoys.multi.KaplanMeier()
     m.fit(G, B, T)
-    assert m.cdf(0, 9) == 0.75
+    assert m.predict(0, 9) == 0.75
 
 
 def test_output_shapes(c=0.3, lambd=0.1, n=1000, k=5):
@@ -68,29 +68,29 @@ def test_output_shapes(c=0.3, lambd=0.1, n=1000, k=5):
     model.fit(X, B, T)
 
     # Generate output without ci
-    assert model.cdf(X[0], 0).shape == ()
-    assert model.cdf([X[0], X[1]], 0).shape == (2,)
-    assert model.cdf([X[0]], [0, 1, 2, 3]).shape == (4,)
-    assert model.cdf([X[0], X[1], X[2]], [0, 1, 2]).shape == (3,)
-    assert model.cdf([[X[0], X[1]]], [[0], [1], [2]]).shape == (3, 2)
-    assert model.cdf([[X[0]], [X[1]]], [[0, 1, 2]]).shape == (2, 3)
+    assert model.predict(X[0], 0).shape == ()
+    assert model.predict([X[0], X[1]], 0).shape == (2,)
+    assert model.predict([X[0]], [0, 1, 2, 3]).shape == (4,)
+    assert model.predict([X[0], X[1], X[2]], [0, 1, 2]).shape == (3,)
+    assert model.predict([[X[0], X[1]]], [[0], [1], [2]]).shape == (3, 2)
+    assert model.predict([[X[0]], [X[1]]], [[0, 1, 2]]).shape == (2, 3)
 
     # Generate output with ci (same as above plus (3,))
-    assert model.cdf(X[0], 0, ci=0.8).shape == (3,)
-    assert model.cdf([X[0], X[1]], 0, ci=0.8).shape == (2, 3)
-    assert model.cdf([X[0]], [0, 1, 2, 3], ci=0.8).shape == (4, 3)
-    assert model.cdf([X[0], X[1], X[2]], [0, 1, 2], ci=0.8) \
+    assert model.predict(X[0], 0, ci=0.8).shape == (3,)
+    assert model.predict([X[0], X[1]], 0, ci=0.8).shape == (2, 3)
+    assert model.predict([X[0]], [0, 1, 2, 3], ci=0.8).shape == (4, 3)
+    assert model.predict([X[0], X[1], X[2]], [0, 1, 2], ci=0.8) \
                 .shape == (3, 3)
-    assert model.cdf([[X[0], X[1]]], [[0], [1], [2]], ci=0.8) \
+    assert model.predict([[X[0], X[1]]], [[0], [1], [2]], ci=0.8) \
                 .shape == (3, 2, 3)
-    assert model.cdf([[X[0]], [X[1]]], [[0, 1, 2]], ci=0.8) \
+    assert model.predict([[X[0]], [X[1]]], [[0, 1, 2]], ci=0.8) \
                 .shape == (2, 3, 3)
 
     # Fit model without ci (should be the same)
     model = convoys.regression.Exponential(ci=False)
     model.fit(X, B, T)
-    assert model.cdf(X[0], 0).shape == ()
-    assert model.cdf([X[0], X[1]], [0, 1]).shape == (2,)
+    assert model.predict(X[0], 0).shape == ()
+    assert model.predict([X[0], X[1]], [0, 1]).shape == (2,)
 
 
 @flaky.flaky
@@ -102,15 +102,15 @@ def test_exponential_regression_model(c=0.3, lambd=0.1, n=10000):
     B, T = generate_censored_data(N, E, C)
     model = convoys.regression.Exponential(ci=True)
     model.fit(X, B, T)
-    assert 0.80*c < model.cdf([1], float('inf')) < 1.30*c
+    assert 0.80*c < model.predict([1], float('inf')) < 1.30*c
     for t in [1, 3, 10]:
         d = 1 - numpy.exp(-lambd*t)
-        assert 0.80*c*d < model.cdf([1], t) < 1.30*c*d
+        assert 0.80*c*d < model.predict([1], t) < 1.30*c*d
 
     # Check the confidence intervals
-    assert model.cdf([1], float('inf'), ci=0.95).shape == (3,)
-    assert model.cdf([1], [0, 1, 2, 3], ci=0.95).shape == (4, 3)
-    y, y_lo, y_hi = model.cdf([1], float('inf'), ci=0.95)
+    assert model.predict([1], float('inf'), ci=0.95).shape == (3,)
+    assert model.predict([1], [0, 1, 2, 3], ci=0.95).shape == (4, 3)
+    y, y_lo, y_hi = model.predict([1], float('inf'), ci=0.95)
     assert 0.80*c < y < 1.30*c
 
     # Check the random variates
@@ -128,7 +128,7 @@ def test_exponential_regression_model(c=0.3, lambd=0.1, n=10000):
     assert 0.9*c < model_c < 1.1*c
     for t in [1, 3, 10]:
         d = 1 - numpy.exp(-lambd*t)
-        assert 0.80*c*d < model.cdf([1], t) < 1.30*c*d
+        assert 0.80*c*d < model.predict([1], t) < 1.30*c*d
 
 
 @flaky.flaky
@@ -148,14 +148,14 @@ def test_weibull_regression_model(cs=[0.3, 0.5, 0.7],
 
     # Validate shape of results
     x = numpy.ones((len(cs),))
-    assert model.cdf(x, float('inf')).shape == ()
-    assert model.cdf(x, 1).shape == ()
-    assert model.cdf(x, [1, 2, 3, 4]).shape == (4,)
+    assert model.predict(x, float('inf')).shape == ()
+    assert model.predict(x, 1).shape == ()
+    assert model.predict(x, [1, 2, 3, 4]).shape == (4,)
 
     # Check results
     for r, c in enumerate(cs):
         x = [int(r == j) for j in range(len(cs))]
-        assert 0.80 * c < model.cdf(x, float('inf')) < 1.30 * c
+        assert 0.80 * c < model.predict(x, float('inf')) < 1.30 * c
 
     # Fit a linear model
     model = convoys.regression.Weibull(ci=False, flavor='linear')
@@ -176,7 +176,7 @@ def test_gamma_regression_model(c=0.3, lambd=0.1, k=3.0, n=10000):
 
     model = convoys.regression.Gamma()
     model.fit(X, B, T)
-    assert 0.80*c < model.cdf([1], float('inf')) < 1.30*c
+    assert 0.80*c < model.predict([1], float('inf')) < 1.30*c
     assert 0.80*k < numpy.mean(model.params['map']['k']) < 1.30*k
 
     # Fit a linear model
@@ -212,10 +212,10 @@ def test_linear_model(n=10000, m=5, k=3.0, lambd=0.1):
     # Check predictions
     for i, c in enumerate(cs):
         x = numpy.array([float(j == i) for j in range(m)])
-        p = model.cdf(x, float('inf'))
+        p = model.predict(x, float('inf'))
         assert c - 0.03 < p < c + 0.03
         t = 10.0
-        p = model.cdf(x, t)
+        p = model.predict(x, t)
         f = 1 - numpy.exp(-(t*lambd)**k)
         assert c*f - 0.03 < p < c*f + 0.03
 
@@ -243,7 +243,7 @@ def test_exponential_pooling(c=0.5, lambd=0.01, n=10000, ks=[1, 2, 3]):
     model.fit(G, B, T)
 
     # Generate predictions for each cohort
-    c = numpy.array([model.cdf(i, float('inf')) for i in range(1+len(ks))])
+    c = numpy.array([model.predict(i, float('inf')) for i in range(1+len(ks))])
     assert numpy.all(c[1:] > 0.25)  # rough check
     assert numpy.all(c[1:] < 0.50)  # same
     assert numpy.all(numpy.diff(c) < 0)  # c should be monotonically decreasing

--- a/test_convoys.py
+++ b/test_convoys.py
@@ -76,15 +76,19 @@ def test_output_shapes(c=0.3, lambd=0.1, n=1000, k=5):
     assert model.predict([[X[0]], [X[1]]], [[0, 1, 2]]).shape == (2, 3)
 
     # Generate output with ci (same as above plus (3,))
-    assert model.predict(X[0], 0, ci=0.8).shape == (3,)
-    assert model.predict([X[0], X[1]], 0, ci=0.8).shape == (2, 3)
-    assert model.predict([X[0]], [0, 1, 2, 3], ci=0.8).shape == (4, 3)
-    assert model.predict([X[0], X[1], X[2]], [0, 1, 2], ci=0.8) \
+    assert model.predict_ci(X[0], 0, ci=0.8).shape == (3,)
+    assert model.predict_ci([X[0], X[1]], 0, ci=0.8).shape == (2, 3)
+    assert model.predict_ci([X[0]], [0, 1, 2, 3], ci=0.8).shape == (4, 3)
+    assert model.predict_ci([X[0], X[1], X[2]], [0, 1, 2], ci=0.8) \
                 .shape == (3, 3)
-    assert model.predict([[X[0], X[1]]], [[0], [1], [2]], ci=0.8) \
+    assert model.predict_ci([[X[0], X[1]]], [[0], [1], [2]], ci=0.8) \
                 .shape == (3, 2, 3)
-    assert model.predict([[X[0]], [X[1]]], [[0, 1, 2]], ci=0.8) \
+    assert model.predict_ci([[X[0]], [X[1]]], [[0, 1, 2]], ci=0.8) \
                 .shape == (2, 3, 3)
+
+    # Assert old interface still works
+    assert model.cdf(X[0], 0).shape == ()
+    assert model.cdf(X[0], 0, ci=0.8).shape == (3,)
 
     # Fit model without ci (should be the same)
     model = convoys.regression.Exponential(ci=False)
@@ -108,9 +112,9 @@ def test_exponential_regression_model(c=0.3, lambd=0.1, n=10000):
         assert 0.80*c*d < model.predict([1], t) < 1.30*c*d
 
     # Check the confidence intervals
-    assert model.predict([1], float('inf'), ci=0.95).shape == (3,)
-    assert model.predict([1], [0, 1, 2, 3], ci=0.95).shape == (4, 3)
-    y, y_lo, y_hi = model.predict([1], float('inf'), ci=0.95)
+    assert model.predict_ci([1], float('inf'), ci=0.95).shape == (3,)
+    assert model.predict_ci([1], [0, 1, 2, 3], ci=0.95).shape == (4, 3)
+    y, y_lo, y_hi = model.predict_ci([1], float('inf'), ci=0.95)
     assert 0.80*c < y < 1.30*c
 
     # Check the random variates


### PR DESCRIPTION
The `cdf` name was an attempt to make it more similar to the probability distributions in `scipy.stats` but in retrospect that was confusing since the convoys models do not represent probability distributions – they are more like regression models that output something between 0 and 1.

This deprecates the old method names but keeps them for the time being.

EDIT: also splits the prediction method into `predict` vs `predict_ci` along the lines of https://martinfowler.com/bliki/FlagArgument.html