### PR TITLE
Speed up plotting using numpy

### DIFF
--- a/convoys/plotting.py
+++ b/convoys/plotting.py
@@ -76,9 +76,8 @@ def plot_cohorts(G, B, T, t_max=None, model='kaplan-meier',
     for i, group in enumerate(specific_groups):
         j = groups.index(group)  # matching index of group
 
-        idx = numpy.where(G == j)
-        n = numpy.sum(idx)
-        k = numpy.sum(B[idx])
+        n = numpy.sum(G == j)
+        k = numpy.sum(B[G == j])
         label = label_fmt % dict(group=group, n=n, k=k)
 
         if ci is not None:

--- a/convoys/plotting.py
+++ b/convoys/plotting.py
@@ -76,8 +76,9 @@ def plot_cohorts(G, B, T, t_max=None, model='kaplan-meier',
     for i, group in enumerate(specific_groups):
         j = groups.index(group)  # matching index of group
 
-        n = sum(1 for g in G if g == j)  # TODO: slow
-        k = sum(1 for g, b in zip(G, B) if g == j and b)  # TODO: slow
+        idx = numpy.where(G == j)
+        n = numpy.sum(idx)
+        k = numpy.sum(B[idx])
         label = label_fmt % dict(group=group, n=n, k=k)
 
         if ci is not None:


### PR DESCRIPTION
Just replaced the slow `TODOs` with some optimized numpy operations to speed up the plotting.

For a group size of 4 on the little snippet of code before the `if ci...`, the time taken on the loop improves from `248 ms ± 3.14 ms per loop`  to `960 µs ± 14.2 µs per loop`. All unit tests pass.