### PR TITLE
n_iterations needs to be an int or generalized gamma model breaks. 

### DIFF
--- a/convoys/regression.py
+++ b/convoys/regression.py
@@ -259,7 +259,7 @@ class GeneralizedGamma(RegressionModel):
             p0 = [result['map'] + mcmc_initial_noise * numpy.random.randn(dim)
                   for i in range(n_walkers)]
             n_burnin = 100
-            n_steps = numpy.ceil(2000. / n_walkers)
+            n_steps = int(numpy.ceil(2000. / n_walkers))
             n_iterations = n_burnin + n_steps
 
             bar = progressbar.ProgressBar(max_value=n_iterations, widgets=[


### PR DESCRIPTION
Hey big fan of the project. 

A Numpy Call to `np.empty` in Emcee is unhappy since numpy 1.11 (I think) that `n_iterations` is a float. 

`np.ceil()` is used to calculate the number of iterations and it returns a float. Changing the result to an int fixes Generalized Gamma as of Numpy version 1.21.2. 

